### PR TITLE
feat: add controlled model scenario intake

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = []
 
 [project.scripts]
 ontology-poc = "ontology_poc_generator.cli:main"
+ontology-poc-recognize = "ontology_poc_generator.recognition_cli:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/ontology_poc_generator/cli.py
+++ b/src/ontology_poc_generator/cli.py
@@ -9,6 +9,7 @@ import tempfile
 from pathlib import Path
 
 from ontology_poc_generator.compiler import compile_decision_pack
+from ontology_poc_generator.decision_pack import render_decision_pack_json
 from ontology_poc_generator.errors import (
     KnowledgeValidationError,
     OntologySpecValidationError,
@@ -34,6 +35,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--ontology-spec-output",
         type=Path,
         help="Write the compiled ontology spec envelope to this file",
+    )
+    parser.add_argument(
+        "--decision-pack-output",
+        type=Path,
+        help="Write the canonical decision pack to this file",
     )
     parser.add_argument(
         "--knowledge-unit",
@@ -109,8 +115,15 @@ def main(argv: list[str] | None = None) -> int:
             else render_json(proposal)
         )
         ontology_spec_content = None
-        if args.ontology_spec_output is not None:
+        decision_pack_content = None
+        if (
+            args.ontology_spec_output is not None
+            or args.decision_pack_output is not None
+        ):
             pack = compile_decision_pack(params, knowledge_units)
+            if args.decision_pack_output is not None:
+                decision_pack_content = render_decision_pack_json(pack)
+        if args.ontology_spec_output is not None:
             compilation = compile_ontology_spec(pack)
             ontology_spec_content = json.dumps(
                 {
@@ -144,27 +157,34 @@ def main(argv: list[str] | None = None) -> int:
         print(f"input error: {exc}", file=sys.stderr)
         return 2
 
-    if args.ontology_spec_output is not None:
-        if args.output is not None:
-            try:
-                outputs_collide = (
-                    str(args.output.resolve()).casefold()
-                    == str(args.ontology_spec_output.resolve()).casefold()
-                )
-            except (OSError, RuntimeError) as exc:
-                print(f"output error: {exc}", file=sys.stderr)
-                return 3
-            if outputs_collide:
-                print(
-                    "output error: --output and --ontology-spec-output "
-                    "must resolve to different files",
-                    file=sys.stderr,
-                )
-                return 3
+    if (
+        args.ontology_spec_output is not None
+        or args.decision_pack_output is not None
+    ):
         requested_outputs = []
         if args.output is not None:
             requested_outputs.append((args.output, content))
-        requested_outputs.append((args.ontology_spec_output, ontology_spec_content))
+        if args.ontology_spec_output is not None:
+            requested_outputs.append(
+                (args.ontology_spec_output, ontology_spec_content)
+            )
+        if args.decision_pack_output is not None:
+            requested_outputs.append(
+                (args.decision_pack_output, decision_pack_content)
+            )
+        try:
+            resolved_outputs = [
+                str(path.resolve()).casefold() for path, _ in requested_outputs
+            ]
+        except (OSError, RuntimeError) as exc:
+            print(f"output error: {exc}", file=sys.stderr)
+            return 3
+        if len(set(resolved_outputs)) != len(resolved_outputs):
+            print(
+                "output error: output paths must resolve to different files",
+                file=sys.stderr,
+            )
+            return 3
         staged_outputs: list[tuple[Path, Path]] = []
         backups: list[tuple[Path, Path | None]] = []
         installed_indexes: list[int] = []

--- a/src/ontology_poc_generator/model_gateway.py
+++ b/src/ontology_poc_generator/model_gateway.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+from typing import Callable
+from urllib.request import Request, urlopen
+
+from ontology_poc_generator.recognition import ModelCompletion, RecognitionError
+
+
+class OpenAICompatibleGateway:
+    """Minimal JSON-mode adapter for an OpenAI-compatible chat endpoint."""
+
+    def __init__(
+        self,
+        *,
+        api_base: str,
+        api_key: str,
+        model: str,
+        timeout_seconds: float = 60,
+        opener: Callable[..., object] = urlopen,
+    ) -> None:
+        for field, value in (
+            ("api_base", api_base),
+            ("api_key", api_key),
+            ("model", model),
+        ):
+            if not isinstance(value, str) or not value.strip():
+                raise RecognitionError(f"{field} is required")
+        if not isinstance(timeout_seconds, (int, float)) or timeout_seconds <= 0:
+            raise RecognitionError("timeout_seconds must be positive")
+        self._api_base = api_base.strip().rstrip("/")
+        self._api_key = api_key.strip()
+        self._model = model.strip()
+        self._timeout_seconds = timeout_seconds
+        self._opener = opener
+
+    def complete_json(
+        self,
+        *,
+        system_prompt: str,
+        user_prompt: str,
+    ) -> ModelCompletion:
+        body = json.dumps(
+            {
+                "model": self._model,
+                "messages": [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+                "response_format": {"type": "json_object"},
+            },
+            ensure_ascii=False,
+        ).encode("utf-8")
+        request = Request(
+            f"{self._api_base}/chat/completions",
+            data=body,
+            headers={
+                "Authorization": f"Bearer {self._api_key}",
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+        try:
+            with self._opener(request, timeout=self._timeout_seconds) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+            content = payload["choices"][0]["message"]["content"]
+            served_model = payload.get("model", self._model)
+            if not isinstance(content, str) or not content.strip():
+                raise TypeError("content")
+            if not isinstance(served_model, str) or not served_model.strip():
+                served_model = self._model
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            raise RecognitionError(f"model request failed: {exc}") from exc
+        except (KeyError, IndexError, TypeError, AttributeError) as exc:
+            raise RecognitionError("invalid model response") from exc
+        return ModelCompletion(
+            provider="openai_compatible",
+            model=served_model,
+            content=content,
+        )

--- a/src/ontology_poc_generator/model_gateway.py
+++ b/src/ontology_poc_generator/model_gateway.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from http.client import HTTPException
 from typing import Callable
 from urllib.request import Request, urlopen
 
@@ -51,16 +52,16 @@ class OpenAICompatibleGateway:
             },
             ensure_ascii=False,
         ).encode("utf-8")
-        request = Request(
-            f"{self._api_base}/chat/completions",
-            data=body,
-            headers={
-                "Authorization": f"Bearer {self._api_key}",
-                "Content-Type": "application/json",
-            },
-            method="POST",
-        )
         try:
+            request = Request(
+                f"{self._api_base}/chat/completions",
+                data=body,
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "Content-Type": "application/json",
+                },
+                method="POST",
+            )
             with self._opener(request, timeout=self._timeout_seconds) as response:
                 payload = json.loads(response.read().decode("utf-8"))
             content = payload["choices"][0]["message"]["content"]
@@ -69,7 +70,13 @@ class OpenAICompatibleGateway:
                 raise TypeError("content")
             if not isinstance(served_model, str) or not served_model.strip():
                 served_model = self._model
-        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        except (
+            OSError,
+            UnicodeError,
+            ValueError,
+            HTTPException,
+            json.JSONDecodeError,
+        ) as exc:
             raise RecognitionError(f"model request failed: {exc}") from exc
         except (KeyError, IndexError, TypeError, AttributeError) as exc:
             raise RecognitionError("invalid model response") from exc

--- a/src/ontology_poc_generator/recognition.py
+++ b/src/ontology_poc_generator/recognition.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+from typing import Protocol
+
+from ontology_poc_generator.compiler import compile_decision_pack
+from ontology_poc_generator.decision_pack import (
+    decision_pack_content_hash,
+    decision_pack_to_dict,
+)
+from ontology_poc_generator.models import ScenarioParameters
+from ontology_poc_generator.ontology_spec import ontology_spec_to_dict
+from ontology_poc_generator.spec_compiler import compile_ontology_spec
+
+
+PROMPT_VERSION = "order_priority_intervention.v1"
+_CANDIDATE_SCHEMA = "scenario_recognition_candidate.v1"
+_SUPPORTED_PROFILE = "order_priority_intervention"
+_CANDIDATE_FIELDS = {
+    "schema",
+    "profile",
+    "industry",
+    "scene_name",
+    "business_decision",
+    "decision_owner",
+    "trigger",
+    "participants",
+    "additional_objects",
+    "constraints",
+    "data_sources",
+    "desired_actions",
+    "acceptance_questions",
+    "notes",
+}
+_PROFILE_OBJECTS = ("客户订单", "物料", "供应商")
+
+_SYSTEM_PROMPT = """你是一个只做候选场景识别的结构化提取器。
+仅当材料描述“哪些客户订单进入优先人工干预队列”时，profile 输出
+order_priority_intervention；否则 profile 输出 unsupported。
+
+只输出一个 JSON 对象，字段必须且只能是：
+schema, profile, industry, scene_name, business_decision, decision_owner, trigger,
+participants, additional_objects, constraints, data_sources, desired_actions,
+acceptance_questions, notes。
+
+schema 固定为 scenario_recognition_candidate.v1。participants、additional_objects、
+constraints、data_sources、desired_actions、acceptance_questions 必须是数组；
+data_sources 每项只能包含 name、type、status，status 只能是 available、to_confirm、
+unavailable。缺失的可选列表输出空数组，但 acceptance_questions 至少一项。
+
+不要输出 decision_key、semantic_key、role_key、关系 ID、规则、threshold、expression、
+score、weight、客户事实、队列结论、Action、发布状态或写回指令。不要把建议说成确认事实。
+"""
+
+
+class RecognitionError(ValueError):
+    """A model response cannot enter the deterministic scenario boundary."""
+
+
+@dataclass(frozen=True)
+class ModelCompletion:
+    provider: str
+    model: str
+    content: str
+
+    def __post_init__(self) -> None:
+        for field in ("provider", "model", "content"):
+            value = getattr(self, field)
+            if not isinstance(value, str) or not value.strip():
+                raise RecognitionError(f"model completion {field} is required")
+            object.__setattr__(self, field, value.strip())
+
+
+class RecognitionGateway(Protocol):
+    def complete_json(
+        self,
+        *,
+        system_prompt: str,
+        user_prompt: str,
+    ) -> ModelCompletion: ...
+
+
+@dataclass(frozen=True)
+class RecognitionResult:
+    prompt_version: str
+    source_text_sha256: str
+    provider: str
+    model: str
+    candidate_json: str
+    scenario: ScenarioParameters
+
+    @property
+    def candidate(self) -> dict[str, object]:
+        value = json.loads(self.candidate_json)
+        assert isinstance(value, dict)
+        return value
+
+
+def _require_string_list(value: object, field: str) -> list[str]:
+    if not isinstance(value, list) or any(
+        not isinstance(item, str) or not item.strip() for item in value
+    ):
+        raise RecognitionError(f"{field} must be a list of non-empty strings")
+    return [item.strip() for item in value]
+
+
+def _validate_candidate(value: object) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise RecognitionError("model response must be a valid JSON object")
+    fields = set(value)
+    missing = sorted(_CANDIDATE_FIELDS - fields)
+    unexpected = sorted(fields - _CANDIDATE_FIELDS)
+    if missing:
+        raise RecognitionError(f"missing fields: {', '.join(missing)}")
+    if unexpected:
+        raise RecognitionError(f"unexpected fields: {', '.join(unexpected)}")
+    if value["schema"] != _CANDIDATE_SCHEMA:
+        raise RecognitionError(f"schema must equal {_CANDIDATE_SCHEMA}")
+    if value["profile"] != _SUPPORTED_PROFILE:
+        raise RecognitionError(f"unsupported profile: {value['profile']}")
+    for field in (
+        "industry",
+        "scene_name",
+        "business_decision",
+        "decision_owner",
+        "trigger",
+    ):
+        if not isinstance(value[field], str) or not value[field].strip():
+            raise RecognitionError(f"{field} is required")
+    if not isinstance(value["notes"], str):
+        raise RecognitionError("notes must be a string")
+    for field in (
+        "participants",
+        "additional_objects",
+        "constraints",
+        "desired_actions",
+        "acceptance_questions",
+    ):
+        value[field] = _require_string_list(value[field], field)
+    if not value["acceptance_questions"]:
+        raise RecognitionError("acceptance_questions must contain at least one item")
+    sources = value["data_sources"]
+    if not isinstance(sources, list) or any(not isinstance(item, dict) for item in sources):
+        raise RecognitionError("data_sources must be a list of objects")
+    for index, source in enumerate(sources):
+        if set(source) != {"name", "type", "status"}:
+            raise RecognitionError(
+                f"data_sources[{index}] must contain only name, type, and status"
+            )
+    return value
+
+
+def _scenario_from_candidate(candidate: dict[str, object]) -> ScenarioParameters:
+    additional_objects = candidate["additional_objects"]
+    assert isinstance(additional_objects, list)
+    objects = list(dict.fromkeys((*_PROFILE_OBJECTS, *additional_objects)))
+    return ScenarioParameters.from_dict(
+        {
+            "industry": candidate["industry"],
+            "scene_name": candidate["scene_name"],
+            "business_decision": candidate["business_decision"],
+            "decision_key": _SUPPORTED_PROFILE,
+            "decision_owner": candidate["decision_owner"],
+            "trigger": candidate["trigger"],
+            "participants": candidate["participants"],
+            "objects": objects,
+            "object_role_bindings": [
+                {
+                    "role_key": "customer_order",
+                    "semantic_key": "order.primary",
+                    "object_label": "客户订单",
+                },
+                {
+                    "role_key": "material",
+                    "semantic_key": "material.required",
+                    "object_label": "物料",
+                },
+                {
+                    "role_key": "supplier",
+                    "semantic_key": "supplier.candidate",
+                    "object_label": "供应商",
+                },
+            ],
+            "declared_bridges": [
+                {
+                    "semantic_key": "customer_order_requires_material",
+                    "source_role_key": "customer_order",
+                    "predicate": "REQUIRES",
+                    "target_role_key": "material",
+                }
+            ],
+            "readiness_declarations": [
+                {
+                    "requirement_key": "queue_entry_evidence_policy",
+                    "status": "to_confirm",
+                }
+            ],
+            "constraints": candidate["constraints"],
+            "data_sources": candidate["data_sources"],
+            "desired_actions": candidate["desired_actions"],
+            "acceptance_questions": candidate["acceptance_questions"],
+            "customer_data_available": False,
+            "notes": candidate["notes"],
+        }
+    )
+
+
+def recognize_scenario(
+    source_text: str,
+    gateway: RecognitionGateway,
+) -> RecognitionResult:
+    if not isinstance(source_text, str) or not source_text.strip():
+        raise RecognitionError("source text is required")
+    normalized_source = source_text.strip()
+    completion = gateway.complete_json(
+        system_prompt=_SYSTEM_PROMPT,
+        user_prompt=f"待识别业务材料：\n{normalized_source}",
+    )
+    try:
+        parsed = json.loads(completion.content)
+    except json.JSONDecodeError as exc:
+        raise RecognitionError("model response must be a valid JSON object") from exc
+    candidate = _validate_candidate(parsed)
+    scenario = _scenario_from_candidate(candidate)
+    candidate_json = json.dumps(
+        candidate,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return RecognitionResult(
+        prompt_version=PROMPT_VERSION,
+        source_text_sha256=hashlib.sha256(normalized_source.encode("utf-8")).hexdigest(),
+        provider=completion.provider,
+        model=completion.model,
+        candidate_json=candidate_json,
+        scenario=scenario,
+    )
+
+
+def build_recognition_demo_envelope(
+    result: RecognitionResult,
+    knowledge_units: tuple[object, ...] = (),
+) -> dict[str, object]:
+    pack = compile_decision_pack(result.scenario, knowledge_units)
+    compilation = compile_ontology_spec(pack)
+    pack_data = decision_pack_to_dict(pack)
+    return {
+        "schema": "model_recognition_demo.v1",
+        "recognition": {
+            "prompt_version": result.prompt_version,
+            "source_text_sha256": result.source_text_sha256,
+            "provider": result.provider,
+            "model": result.model,
+            "candidate": result.candidate,
+        },
+        "scenario": pack_data["scenario"],
+        "decision_pack": {
+            "content_hash": decision_pack_content_hash(pack),
+            "pack": pack_data,
+        },
+        "ontology_spec": {
+            "content_hash": compilation.spec_content_hash,
+            "compilation_status": compilation.compilation_status.value,
+            "reference_closure": {
+                "is_closed": compilation.closure_report.is_closed,
+                "checked_reference_count": compilation.closure_report.checked_reference_count,
+                "issues": [
+                    {
+                        "issue_id": issue.issue_id,
+                        "code": issue.code,
+                        "owner_id": issue.owner_id,
+                        "field": issue.field,
+                        "referenced_id": issue.referenced_id,
+                    }
+                    for issue in compilation.closure_report.issues
+                ],
+            },
+            "spec": ontology_spec_to_dict(compilation.spec),
+        },
+    }

--- a/src/ontology_poc_generator/recognition.py
+++ b/src/ontology_poc_generator/recognition.py
@@ -16,42 +16,87 @@ from ontology_poc_generator.spec_compiler import compile_ontology_spec
 
 
 PROMPT_VERSION = "order_priority_intervention.v1"
-_CANDIDATE_SCHEMA = "scenario_recognition_candidate.v1"
+_CANDIDATE_SCHEMA = "scenario_intake_candidate.v1"
 _SUPPORTED_PROFILE = "order_priority_intervention"
 _CANDIDATE_FIELDS = {
     "schema",
-    "profile",
-    "industry",
-    "scene_name",
-    "business_decision",
+    "match_status",
+    "profile_key",
     "decision_owner",
     "trigger",
-    "participants",
-    "additional_objects",
-    "constraints",
-    "data_sources",
-    "desired_actions",
-    "acceptance_questions",
-    "notes",
+    "participant_keys",
+    "constraint_keys",
+    "data_source_statuses",
+    "desired_action_keys",
+    "missing_required_fields",
 }
-_PROFILE_OBJECTS = ("客户订单", "物料", "供应商")
+_MATCH_STATUSES = {"matched", "insufficient_information", "unsupported"}
+_SOURCE_STATUSES = {"available", "to_confirm", "unavailable"}
+_MISSING_FIELDS = ("decision_owner", "trigger")
+
+_PARTICIPANTS = {
+    "order_manager": "订单经理",
+    "procurement_owner": "采购负责人",
+    "production_planner": "生产计划员",
+    "logistics_owner": "物流负责人",
+}
+_CONSTRAINTS = {
+    "erp_transaction_authority": "ERP 仍是交易事实权威",
+    "supplier_commitment_requires_evidence": "缺少供应商承诺时不得推断为已确认交期",
+    "high_risk_requires_human_confirmation": "高风险处置必须由指定责任人确认",
+}
+_NO_WRITEBACK_KEY = "no_erp_writeback"
+_CONSTRAINT_KEYS = (*_CONSTRAINTS, _NO_WRITEBACK_KEY)
+_DATA_SOURCES = {
+    "erp_order_material": ("ERP 订单与物料数据", "database"),
+    "supplier_commitment_feedback": ("供应商交期反馈", "spreadsheet"),
+    "logistics_node_status": ("物流节点状态", "api"),
+}
+_DESIRED_ACTIONS = {
+    "create_order_exception_review_task": "创建订单异常核查任务",
+    "assign_procurement_or_planning_owner": "指定采购或计划责任人",
+    "record_verdict_and_override_reason": "记录接受、拒绝和人工覆盖理由",
+}
+_PROFILE_OBJECTS = (
+    "客户订单",
+    "订单行",
+    "物料",
+    "供应商",
+    "采购承诺",
+    "生产任务",
+    "物流节点",
+    "履约风险",
+    "处置任务",
+)
+_ACCEPTANCE_QUESTIONS = (
+    "系统能否解释订单风险由哪些物料、供应商承诺和生产节点共同造成？",
+    "业务人员修改一条约束后，风险排序和待办对象是否同步变化？",
+    "无法获得物流状态时，系统是否明确显示信息不足而不是给出确定结论？",
+)
+_NO_WRITEBACK_NOTE = "POC 从只读分析和内部任务开始，不直接回写 ERP。"
 
 _SYSTEM_PROMPT = """你是一个只做候选场景识别的结构化提取器。
-仅当材料描述“哪些客户订单进入优先人工干预队列”时，profile 输出
-order_priority_intervention；否则 profile 输出 unsupported。
+只输出 scenario_intake_candidate.v1 JSON 对象，字段必须且只能是：
+schema, match_status, profile_key, decision_owner, trigger, participant_keys,
+constraint_keys, data_source_statuses, desired_action_keys, missing_required_fields。
 
-只输出一个 JSON 对象，字段必须且只能是：
-schema, profile, industry, scene_name, business_decision, decision_owner, trigger,
-participants, additional_objects, constraints, data_sources, desired_actions,
-acceptance_questions, notes。
+match_status 只能是 matched、insufficient_information、unsupported。
+仅当材料明确描述“哪些客户订单进入优先人工干预队列”时输出 matched，profile_key
+固定为 order_priority_intervention；信息不够时输出 insufficient_information；其他场景
+输出 unsupported，不要选择最接近的 profile。
 
-schema 固定为 scenario_recognition_candidate.v1。participants、additional_objects、
-constraints、data_sources、desired_actions、acceptance_questions 必须是数组；
-data_sources 每项只能包含 name、type、status，status 只能是 available、to_confirm、
-unavailable。缺失的可选列表输出空数组，但 acceptance_questions 至少一项。
+participant_keys 只能使用 order_manager、procurement_owner、production_planner、
+logistics_owner。constraint_keys 只能使用 erp_transaction_authority、
+supplier_commitment_requires_evidence、high_risk_requires_human_confirmation、
+no_erp_writeback。data_source_statuses 每项只能包含 source_key 和 status；source_key
+只能使用 erp_order_material、supplier_commitment_feedback、logistics_node_status，status
+只能使用 available、to_confirm、unavailable。desired_action_keys 只能使用
+create_order_exception_review_task、assign_procurement_or_planning_owner、
+record_verdict_and_override_reason。missing_required_fields 只能使用 decision_owner、trigger。
 
-不要输出 decision_key、semantic_key、role_key、关系 ID、规则、threshold、expression、
-score、weight、客户事实、队列结论、Action、发布状态或写回指令。不要把建议说成确认事实。
+除 decision_owner 和 trigger 外，不要输出自由文本。不要输出对象、语义 ID、关系、
+readiness、customer data、规则、threshold、expression、score、weight、客户事实、
+队列结论、Action、发布状态或写回指令。
 """
 
 
@@ -98,12 +143,60 @@ class RecognitionResult:
         return value
 
 
-def _require_string_list(value: object, field: str) -> list[str]:
-    if not isinstance(value, list) or any(
-        not isinstance(item, str) or not item.strip() for item in value
-    ):
-        raise RecognitionError(f"{field} must be a list of non-empty strings")
-    return [item.strip() for item in value]
+def _require_optional_text(
+    value: object,
+    field: str,
+    maximum_length: int,
+) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise RecognitionError(f"{field} must be a non-empty string or null")
+    normalized = value.strip()
+    if len(normalized) > maximum_length:
+        raise RecognitionError(f"{field} exceeds {maximum_length} characters")
+    return normalized
+
+
+def _require_controlled_keys(
+    value: object,
+    field: str,
+    allowed_keys: tuple[str, ...],
+) -> list[str]:
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        raise RecognitionError(f"{field} must be a list of controlled keys")
+    if len(set(value)) != len(value):
+        raise RecognitionError(f"duplicate {field}")
+    unknown = sorted(set(value) - set(allowed_keys))
+    if unknown:
+        raise RecognitionError(f"unknown {field}: {', '.join(unknown)}")
+    selected = set(value)
+    return [key for key in allowed_keys if key in selected]
+
+
+def _require_data_source_statuses(value: object) -> list[dict[str, str]]:
+    if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+        raise RecognitionError("data_source_statuses must be a list of objects")
+    selected: dict[str, str] = {}
+    for index, item in enumerate(value):
+        if set(item) != {"source_key", "status"}:
+            raise RecognitionError(
+                f"data_source_statuses[{index}] must contain only source_key and status"
+            )
+        source_key = item["source_key"]
+        status = item["status"]
+        if not isinstance(source_key, str) or source_key not in _DATA_SOURCES:
+            raise RecognitionError(f"unknown data source key: {source_key}")
+        if source_key in selected:
+            raise RecognitionError(f"duplicate data source key: {source_key}")
+        if not isinstance(status, str) or status not in _SOURCE_STATUSES:
+            raise RecognitionError(f"unsupported data source status: {status}")
+        selected[source_key] = status
+    return [
+        {"source_key": key, "status": selected[key]}
+        for key in _DATA_SOURCES
+        if key in selected
+    ]
 
 
 def _validate_candidate(value: object) -> dict[str, object]:
@@ -118,54 +211,111 @@ def _validate_candidate(value: object) -> dict[str, object]:
         raise RecognitionError(f"unexpected fields: {', '.join(unexpected)}")
     if value["schema"] != _CANDIDATE_SCHEMA:
         raise RecognitionError(f"schema must equal {_CANDIDATE_SCHEMA}")
-    if value["profile"] != _SUPPORTED_PROFILE:
-        raise RecognitionError(f"unsupported profile: {value['profile']}")
-    for field in (
-        "industry",
-        "scene_name",
-        "business_decision",
-        "decision_owner",
-        "trigger",
-    ):
-        if not isinstance(value[field], str) or not value[field].strip():
-            raise RecognitionError(f"{field} is required")
-    if not isinstance(value["notes"], str):
-        raise RecognitionError("notes must be a string")
-    for field in (
-        "participants",
-        "additional_objects",
-        "constraints",
-        "desired_actions",
-        "acceptance_questions",
-    ):
-        value[field] = _require_string_list(value[field], field)
-    if not value["acceptance_questions"]:
-        raise RecognitionError("acceptance_questions must contain at least one item")
-    sources = value["data_sources"]
-    if not isinstance(sources, list) or any(not isinstance(item, dict) for item in sources):
-        raise RecognitionError("data_sources must be a list of objects")
-    for index, source in enumerate(sources):
-        if set(source) != {"name", "type", "status"}:
+    match_status = value["match_status"]
+    if not isinstance(match_status, str) or match_status not in _MATCH_STATUSES:
+        raise RecognitionError(f"unsupported match_status: {match_status}")
+    profile_key = value["profile_key"]
+    if profile_key is not None and not isinstance(profile_key, str):
+        raise RecognitionError("profile_key must be a string or null")
+    decision_owner = _require_optional_text(
+        value["decision_owner"], "decision_owner", 80
+    )
+    trigger = _require_optional_text(value["trigger"], "trigger", 300)
+    participant_keys = _require_controlled_keys(
+        value["participant_keys"], "participant_keys", tuple(_PARTICIPANTS)
+    )
+    constraint_keys = _require_controlled_keys(
+        value["constraint_keys"], "constraint_keys", _CONSTRAINT_KEYS
+    )
+    data_source_statuses = _require_data_source_statuses(value["data_source_statuses"])
+    desired_action_keys = _require_controlled_keys(
+        value["desired_action_keys"], "desired_action_keys", tuple(_DESIRED_ACTIONS)
+    )
+    missing_required_fields = _require_controlled_keys(
+        value["missing_required_fields"],
+        "missing_required_fields",
+        _MISSING_FIELDS,
+    )
+
+    canonical: dict[str, object] = {
+        "schema": _CANDIDATE_SCHEMA,
+        "match_status": match_status,
+        "profile_key": profile_key,
+        "decision_owner": decision_owner,
+        "trigger": trigger,
+        "participant_keys": participant_keys,
+        "constraint_keys": constraint_keys,
+        "data_source_statuses": data_source_statuses,
+        "desired_action_keys": desired_action_keys,
+        "missing_required_fields": missing_required_fields,
+    }
+    if match_status == "matched":
+        if profile_key != _SUPPORTED_PROFILE:
             raise RecognitionError(
-                f"data_sources[{index}] must contain only name, type, and status"
+                f"matched profile_key must equal {_SUPPORTED_PROFILE}"
             )
-    return value
+        if decision_owner is None:
+            raise RecognitionError("decision_owner is required for matched candidate")
+        if trigger is None:
+            raise RecognitionError("trigger is required for matched candidate")
+        if missing_required_fields:
+            raise RecognitionError("matched candidate cannot have missing required fields")
+        return canonical
+    if match_status == "insufficient_information":
+        if profile_key != _SUPPORTED_PROFILE:
+            raise RecognitionError(
+                f"insufficient profile_key must equal {_SUPPORTED_PROFILE}"
+            )
+        if not missing_required_fields:
+            raise RecognitionError("insufficient information must identify missing fields")
+        for field in _MISSING_FIELDS:
+            is_missing = field in missing_required_fields
+            has_value = canonical[field] is not None
+            if is_missing == has_value:
+                raise RecognitionError(
+                    f"{field} must be null exactly when listed as missing"
+                )
+        raise RecognitionError("insufficient information; scenario was not compiled")
+    if any(
+        (
+            profile_key is not None,
+            decision_owner is not None,
+            trigger is not None,
+            participant_keys,
+            constraint_keys,
+            data_source_statuses,
+            desired_action_keys,
+            missing_required_fields,
+        )
+    ):
+        raise RecognitionError("unsupported candidate must not contain profile data")
+    raise RecognitionError("unsupported scenario; no closest profile fallback")
 
 
 def _scenario_from_candidate(candidate: dict[str, object]) -> ScenarioParameters:
-    additional_objects = candidate["additional_objects"]
-    assert isinstance(additional_objects, list)
-    objects = list(dict.fromkeys((*_PROFILE_OBJECTS, *additional_objects)))
+    participant_keys = candidate["participant_keys"]
+    constraint_keys = candidate["constraint_keys"]
+    source_status_items = candidate["data_source_statuses"]
+    desired_action_keys = candidate["desired_action_keys"]
+    assert isinstance(participant_keys, list)
+    assert isinstance(constraint_keys, list)
+    assert isinstance(source_status_items, list)
+    assert isinstance(desired_action_keys, list)
+    source_statuses = {
+        item["source_key"]: item["status"]
+        for item in source_status_items
+        if isinstance(item, dict)
+    }
     return ScenarioParameters.from_dict(
         {
-            "industry": candidate["industry"],
-            "scene_name": candidate["scene_name"],
-            "business_decision": candidate["business_decision"],
+            "industry": "制造业供应链",
+            "scene_name": "外贸订单履约风险识别与异常处置",
+            "business_decision": "哪些订单进入优先干预队列",
             "decision_key": _SUPPORTED_PROFILE,
             "decision_owner": candidate["decision_owner"],
             "trigger": candidate["trigger"],
-            "participants": candidate["participants"],
-            "objects": objects,
+            "participants": [_PARTICIPANTS[key] for key in participant_keys],
+            "objects": list(_PROFILE_OBJECTS),
             "object_role_bindings": [
                 {
                     "role_key": "customer_order",
@@ -197,12 +347,26 @@ def _scenario_from_candidate(candidate: dict[str, object]) -> ScenarioParameters
                     "status": "to_confirm",
                 }
             ],
-            "constraints": candidate["constraints"],
-            "data_sources": candidate["data_sources"],
-            "desired_actions": candidate["desired_actions"],
-            "acceptance_questions": candidate["acceptance_questions"],
+            "constraints": [
+                _CONSTRAINTS[key] for key in constraint_keys if key in _CONSTRAINTS
+            ],
+            "data_sources": [
+                {
+                    "name": name,
+                    "type": source_type,
+                    "status": source_statuses.get(source_key, "to_confirm"),
+                }
+                for source_key, (name, source_type) in _DATA_SOURCES.items()
+            ],
+            "desired_actions": [
+                _DESIRED_ACTIONS[key] for key in desired_action_keys
+            ],
+            "acceptance_questions": list(_ACCEPTANCE_QUESTIONS),
             "customer_data_available": False,
-            "notes": candidate["notes"],
+            "notes": (
+                _NO_WRITEBACK_NOTE if _NO_WRITEBACK_KEY in constraint_keys else ""
+            ),
+            "relations": [],
         }
     )
 

--- a/src/ontology_poc_generator/recognition_cli.py
+++ b/src/ontology_poc_generator/recognition_cli.py
@@ -63,8 +63,29 @@ def _write_atomic(path: Path, content: str) -> None:
         temporary_path.unlink(missing_ok=True)
 
 
+def _validate_output_path(
+    output: Path | None,
+    input_path: Path,
+    knowledge_units: list[Path],
+) -> None:
+    if output is None:
+        return
+    output_identity = os.fspath(output.resolve()).casefold()
+    input_identities = {
+        os.fspath(path.resolve()).casefold()
+        for path in (input_path, *knowledge_units)
+    }
+    if output_identity in input_identities:
+        raise ValueError("output path collides with an input path")
+
+
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    try:
+        _validate_output_path(args.output, args.input, args.knowledge_units)
+    except (OSError, RuntimeError, ValueError) as exc:
+        print(f"output error: {exc}", file=sys.stderr)
+        return 3
     try:
         api_base = args.api_base or os.environ.get("EIP_MODEL_API_BASE", "")
         model = args.model or os.environ.get("EIP_MODEL_NAME", "")

--- a/src/ontology_poc_generator/recognition_cli.py
+++ b/src/ontology_poc_generator/recognition_cli.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+
+from ontology_poc_generator.errors import (
+    KnowledgeValidationError,
+    OntologySpecValidationError,
+    ScenarioValidationError,
+    SpecCompilationError,
+)
+from ontology_poc_generator.knowledge import load_knowledge_unit
+from ontology_poc_generator.model_gateway import OpenAICompatibleGateway
+from ontology_poc_generator.recognition import (
+    RecognitionError,
+    build_recognition_demo_envelope,
+    recognize_scenario,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Recognize one supported decision scenario and compile demo artifacts."
+    )
+    parser.add_argument("input", type=Path, help="UTF-8 business description")
+    parser.add_argument("--api-base", help="OpenAI-compatible API base URL")
+    parser.add_argument("--model", help="Configured model name")
+    parser.add_argument(
+        "--api-key-env",
+        default="EIP_MODEL_API_KEY",
+        help="Environment variable containing the model API key",
+    )
+    parser.add_argument("--output", type=Path, help="Write the demo envelope atomically")
+    parser.add_argument(
+        "--knowledge-unit",
+        dest="knowledge_units",
+        action="append",
+        type=Path,
+        default=[],
+        metavar="PATH",
+        help="Load a candidate knowledge unit (repeatable, opt-in)",
+    )
+    return parser
+
+
+def _write_atomic(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    os.close(descriptor)
+    temporary_path = Path(temporary_name)
+    try:
+        temporary_path.write_text(content, encoding="utf-8")
+        os.replace(temporary_path, path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        api_base = args.api_base or os.environ.get("EIP_MODEL_API_BASE", "")
+        model = args.model or os.environ.get("EIP_MODEL_NAME", "")
+        api_key = os.environ.get(args.api_key_env, "")
+        if not api_base:
+            raise RecognitionError("api base is required")
+        if not model:
+            raise RecognitionError("model is required")
+        if not api_key:
+            raise RecognitionError(f"model API key is required in {args.api_key_env}")
+        source_text = args.input.read_text(encoding="utf-8")
+        gateway = OpenAICompatibleGateway(
+            api_base=api_base,
+            api_key=api_key,
+            model=model,
+        )
+        result = recognize_scenario(source_text, gateway)
+        knowledge_units = tuple(
+            load_knowledge_unit(path) for path in args.knowledge_units
+        )
+        envelope = build_recognition_demo_envelope(result, knowledge_units)
+        content = json.dumps(
+            envelope,
+            ensure_ascii=False,
+            sort_keys=True,
+            indent=2,
+        )
+    except (
+        OSError,
+        UnicodeError,
+        KnowledgeValidationError,
+        OntologySpecValidationError,
+        RecognitionError,
+        ScenarioValidationError,
+        SpecCompilationError,
+    ) as exc:
+        print(f"input error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.output is None:
+        print(content)
+        return 0
+    try:
+        _write_atomic(args.output, content)
+    except (OSError, UnicodeError) as exc:
+        print(f"output error: {exc}", file=sys.stderr)
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,11 @@ from pathlib import Path
 from unittest.mock import patch
 
 from ontology_poc_generator.cli import _stage_output, build_parser, main
+from ontology_poc_generator.compiler import compile_decision_pack
+from ontology_poc_generator.decision_pack import render_decision_pack_json
 from ontology_poc_generator.errors import SpecCompilationError
+from ontology_poc_generator.knowledge import load_knowledge_unit
+from ontology_poc_generator.models import ScenarioParameters
 
 
 class CliTest(unittest.TestCase):
@@ -90,6 +94,13 @@ class CliTest(unittest.TestCase):
         )
 
         self.assertEqual(args.ontology_spec_output, Path("ontology-spec.json"))
+
+    def test_parser_accepts_decision_pack_output_path(self):
+        args = build_parser().parse_args(
+            ["scenario.json", "--decision-pack-output", "decision-pack.json"]
+        )
+
+        self.assertEqual(args.decision_pack_output, Path("decision-pack.json"))
 
     def test_omitting_ontology_spec_output_preserves_fixed_proposal_bytes(self):
         cases = (
@@ -173,6 +184,42 @@ class CliTest(unittest.TestCase):
                     for issue in payload["spec"]["compilation_issues"]
                 )
             )
+
+    def test_cli_writes_canonical_decision_pack_instead_of_proposal_projection(self):
+        with tempfile.TemporaryDirectory() as directory:
+            output_path = Path(directory) / "decision-pack.json"
+
+            result = self._run_cli(
+                "examples/supply_chain_exception.json",
+                "--knowledge-unit",
+                str(self.KNOWLEDGE_PATH),
+                "--format",
+                "json",
+                "--decision-pack-output",
+                str(output_path),
+            )
+
+            raw_scenario = json.loads(
+                (self.REPO_ROOT / "examples/supply_chain_exception.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            expected_pack = compile_decision_pack(
+                ScenarioParameters.from_dict(raw_scenario),
+                (load_knowledge_unit(self.KNOWLEDGE_PATH),),
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stderr, "")
+            self.assertEqual(
+                output_path.read_text(encoding="utf-8"),
+                render_decision_pack_json(expected_pack),
+            )
+            payload = json.loads(output_path.read_text(encoding="utf-8"))
+            self.assertEqual(payload["schema"], "decision_pack.v1")
+            self.assertIn("input_bindings", payload)
+            self.assertIn("source_refs", payload)
+            self.assertIn("knowledge_outcomes", payload)
+            self.assertNotIn("primary_decision", payload)
 
     def test_spec_compilation_failure_is_an_input_error_without_outputs(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -280,6 +327,62 @@ class CliTest(unittest.TestCase):
             )
             self.assertEqual(list(root.glob(".*.tmp")), [])
             self.assertEqual(list(root.glob(".*.bak")), [])
+
+    def test_cli_rejects_decision_pack_collision_with_any_other_output(self):
+        cases = (
+            ("--output", "proposal.json"),
+            ("--ontology-spec-output", "ontology-spec.json"),
+        )
+        for other_flag, other_name in cases:
+            with self.subTest(other_flag=other_flag):
+                with tempfile.TemporaryDirectory() as directory:
+                    root = Path(directory)
+                    other_output = root / other_name
+                    decision_output = root / other_name.upper()
+                    original = b"original output\n"
+                    other_output.write_bytes(original)
+
+                    result = self._run_cli(
+                        "examples/supply_chain_exception.json",
+                        "--format",
+                        "json",
+                        other_flag,
+                        str(other_output),
+                        "--decision-pack-output",
+                        str(decision_output),
+                    )
+
+                    self.assertEqual(result.returncode, 3)
+                    self.assertIn("output error:", result.stderr)
+                    self.assertEqual(result.stdout, "")
+                    self.assertEqual(other_output.read_bytes(), original)
+                    self.assertEqual(list(root.glob(".*.tmp")), [])
+                    self.assertEqual(list(root.glob(".*.bak")), [])
+
+    def test_failed_decision_pack_staging_leaves_no_other_outputs(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            proposal_output = root / "proposal.json"
+            spec_output = root / "ontology-spec.json"
+
+            result = self._run_cli(
+                "examples/supply_chain_exception.json",
+                "--format",
+                "json",
+                "--output",
+                str(proposal_output),
+                "--ontology-spec-output",
+                str(spec_output),
+                "--decision-pack-output",
+                "/dev/null/decision-pack.json",
+            )
+
+            self.assertEqual(result.returncode, 3)
+            self.assertIn("output error:", result.stderr)
+            self.assertEqual(result.stdout, "")
+            self.assertFalse(proposal_output.exists())
+            self.assertFalse(spec_output.exists())
+            self.assertEqual(list(root.iterdir()), [])
 
     def test_failed_spec_staging_leaves_no_new_proposal_or_temp_file(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_model_gateway.py
+++ b/tests/test_model_gateway.py
@@ -84,6 +84,17 @@ class OpenAICompatibleGatewayTest(unittest.TestCase):
             gateway.complete_json(system_prompt="system", user_prompt="user")
         self.assertNotIn("secret-value", str(raised.exception))
 
+    def test_invalid_request_url_is_wrapped_as_recognition_error(self) -> None:
+        gateway = OpenAICompatibleGateway(
+            api_base="https://models.example/invalid\npath",
+            api_key="secret-value",
+            model="configured-model",
+        )
+
+        with self.assertRaisesRegex(RecognitionError, "model request failed") as raised:
+            gateway.complete_json(system_prompt="system", user_prompt="user")
+        self.assertIs(type(raised.exception), RecognitionError)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_model_gateway.py
+++ b/tests/test_model_gateway.py
@@ -1,0 +1,89 @@
+import io
+import json
+import unittest
+
+from ontology_poc_generator.model_gateway import OpenAICompatibleGateway
+from ontology_poc_generator.recognition import RecognitionError
+
+
+class FakeResponse:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self.payload = payload
+
+    def __enter__(self) -> "FakeResponse":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self.payload).encode("utf-8")
+
+
+class OpenAICompatibleGatewayTest(unittest.TestCase):
+    def test_posts_json_mode_without_exposing_key_in_body(self) -> None:
+        observed: dict[str, object] = {}
+
+        def opener(request: object, timeout: float) -> FakeResponse:
+            observed["request"] = request
+            observed["timeout"] = timeout
+            return FakeResponse(
+                {
+                    "model": "served-model",
+                    "choices": [{"message": {"content": '{"schema":"ok"}'}}],
+                }
+            )
+
+        gateway = OpenAICompatibleGateway(
+            api_base="https://models.example/v1/",
+            api_key="secret-value",
+            model="configured-model",
+            timeout_seconds=12,
+            opener=opener,
+        )
+
+        completion = gateway.complete_json(
+            system_prompt="system",
+            user_prompt="user",
+        )
+
+        request = observed["request"]
+        body = json.loads(request.data.decode("utf-8"))
+        self.assertEqual(request.full_url, "https://models.example/v1/chat/completions")
+        self.assertEqual(request.headers["Authorization"], "Bearer secret-value")
+        self.assertNotIn("secret-value", request.data.decode("utf-8"))
+        self.assertEqual(body["response_format"], {"type": "json_object"})
+        self.assertEqual(body["model"], "configured-model")
+        self.assertEqual(observed["timeout"], 12)
+        self.assertEqual(completion.model, "served-model")
+        self.assertEqual(completion.content, '{"schema":"ok"}')
+
+    def test_invalid_provider_response_fails_loudly(self) -> None:
+        gateway = OpenAICompatibleGateway(
+            api_base="https://models.example/v1",
+            api_key="secret-value",
+            model="configured-model",
+            opener=lambda request, timeout: FakeResponse({"choices": []}),
+        )
+
+        with self.assertRaisesRegex(RecognitionError, "invalid model response"):
+            gateway.complete_json(system_prompt="system", user_prompt="user")
+
+    def test_network_failure_is_wrapped_without_key(self) -> None:
+        def failing_opener(request: object, timeout: float) -> object:
+            raise OSError("connection refused")
+
+        gateway = OpenAICompatibleGateway(
+            api_base="https://models.example/v1",
+            api_key="secret-value",
+            model="configured-model",
+            opener=failing_opener,
+        )
+
+        with self.assertRaisesRegex(RecognitionError, "model request failed") as raised:
+            gateway.complete_json(system_prompt="system", user_prompt="user")
+        self.assertNotIn("secret-value", str(raised.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_recognition.py
+++ b/tests/test_recognition.py
@@ -1,0 +1,117 @@
+import json
+import unittest
+
+from ontology_poc_generator.recognition import (
+    ModelCompletion,
+    RecognitionError,
+    build_recognition_demo_envelope,
+    recognize_scenario,
+)
+
+
+def candidate(**overrides: object) -> dict[str, object]:
+    value: dict[str, object] = {
+        "schema": "scenario_recognition_candidate.v1",
+        "profile": "order_priority_intervention",
+        "industry": "制造业供应链",
+        "scene_name": "订单履约异常识别",
+        "business_decision": "哪些订单进入优先干预队列",
+        "decision_owner": "供应链计划经理",
+        "trigger": "订单交期或物料齐套状态异常时",
+        "participants": ["订单经理", "采购负责人"],
+        "additional_objects": ["订单行", "采购承诺"],
+        "constraints": ["ERP 仍是交易事实权威"],
+        "data_sources": [
+            {"name": "ERP 订单数据", "type": "database", "status": "to_confirm"}
+        ],
+        "desired_actions": ["创建人工核查任务"],
+        "acceptance_questions": ["能否解释候选队列依据？"],
+        "notes": "只读演示，不回写 ERP。",
+    }
+    value.update(overrides)
+    return value
+
+
+class FakeGateway:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self.payload = payload
+        self.calls: list[tuple[str, str]] = []
+
+    def complete_json(self, *, system_prompt: str, user_prompt: str) -> ModelCompletion:
+        self.calls.append((system_prompt, user_prompt))
+        return ModelCompletion(
+            provider="openai_compatible",
+            model="demo-model",
+            content=json.dumps(self.payload, ensure_ascii=False),
+        )
+
+
+class RecognitionContractTest(unittest.TestCase):
+    def test_recognized_profile_uses_fixed_semantic_identity_and_safe_boundary(self) -> None:
+        gateway = FakeGateway(candidate())
+
+        result = recognize_scenario("订单可能延期，请识别干预场景。", gateway)
+
+        self.assertEqual(result.prompt_version, "order_priority_intervention.v1")
+        self.assertEqual(len(result.source_text_sha256), 64)
+        self.assertEqual(result.provider, "openai_compatible")
+        self.assertEqual(result.model, "demo-model")
+        self.assertEqual(result.scenario.decision_key, "order_priority_intervention")
+        self.assertFalse(result.scenario.customer_data_available)
+        self.assertEqual(
+            [(item.role_key, item.semantic_key, item.object_label) for item in result.scenario.object_role_bindings],
+            [
+                ("customer_order", "order.primary", "客户订单"),
+                ("material", "material.required", "物料"),
+                ("supplier", "supplier.candidate", "供应商"),
+            ],
+        )
+        self.assertEqual(len(result.scenario.declared_bridges), 1)
+        self.assertEqual(result.scenario.declared_bridges[0].predicate, "REQUIRES")
+        self.assertEqual(result.scenario.readiness_declarations[0].status.value, "to_confirm")
+        self.assertIn("订单可能延期", gateway.calls[0][1])
+
+    def test_candidate_must_match_exact_non_executable_contract(self) -> None:
+        invalid = candidate(score=0.9)
+
+        with self.assertRaisesRegex(RecognitionError, "unexpected fields: score"):
+            recognize_scenario("订单异常", FakeGateway(invalid))
+
+    def test_unsupported_profile_fails_loudly(self) -> None:
+        with self.assertRaisesRegex(RecognitionError, "unsupported profile"):
+            recognize_scenario(
+                "请选择供应商",
+                FakeGateway(candidate(profile="supplier_selection")),
+            )
+
+    def test_model_response_must_be_a_json_object(self) -> None:
+        class InvalidGateway:
+            def complete_json(self, *, system_prompt: str, user_prompt: str) -> ModelCompletion:
+                return ModelCompletion("openai_compatible", "demo-model", "not-json")
+
+        with self.assertRaisesRegex(RecognitionError, "valid JSON object"):
+            recognize_scenario("订单异常", InvalidGateway())
+
+    def test_demo_envelope_compiles_closed_candidate_without_actions_or_facts(self) -> None:
+        result = recognize_scenario("订单异常", FakeGateway(candidate()))
+
+        envelope = build_recognition_demo_envelope(result)
+
+        self.assertEqual(envelope["schema"], "model_recognition_demo.v1")
+        self.assertEqual(len(envelope["decision_pack"]["content_hash"]), 64)
+        self.assertEqual(len(envelope["ontology_spec"]["content_hash"]), 64)
+        self.assertEqual(envelope["ontology_spec"]["compilation_status"], "complete")
+        self.assertTrue(envelope["ontology_spec"]["reference_closure"]["is_closed"])
+        serialized = json.dumps(envelope, ensure_ascii=False)
+        for forbidden in (
+            '"facts"',
+            '"score"',
+            '"actions_executed"',
+            '"external_write"',
+            '"published"',
+        ):
+            self.assertNotIn(forbidden, serialized)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_recognition.py
+++ b/tests/test_recognition.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 import unittest
 
 from ontology_poc_generator.recognition import (
@@ -7,26 +8,42 @@ from ontology_poc_generator.recognition import (
     build_recognition_demo_envelope,
     recognize_scenario,
 )
+from ontology_poc_generator.models import ScenarioParameters
+
+
+EXAMPLE_PATH = Path(__file__).parents[1] / "examples" / "supply_chain_exception.json"
 
 
 def candidate(**overrides: object) -> dict[str, object]:
     value: dict[str, object] = {
-        "schema": "scenario_recognition_candidate.v1",
-        "profile": "order_priority_intervention",
-        "industry": "制造业供应链",
-        "scene_name": "订单履约异常识别",
-        "business_decision": "哪些订单进入优先干预队列",
+        "schema": "scenario_intake_candidate.v1",
+        "match_status": "matched",
+        "profile_key": "order_priority_intervention",
         "decision_owner": "供应链计划经理",
-        "trigger": "订单交期或物料齐套状态异常时",
-        "participants": ["订单经理", "采购负责人"],
-        "additional_objects": ["订单行", "采购承诺"],
-        "constraints": ["ERP 仍是交易事实权威"],
-        "data_sources": [
-            {"name": "ERP 订单数据", "type": "database", "status": "to_confirm"}
+        "trigger": "订单预计交期、物料齐套或供应商承诺发生异常时",
+        "participant_keys": [
+            "order_manager",
+            "procurement_owner",
+            "production_planner",
+            "logistics_owner",
         ],
-        "desired_actions": ["创建人工核查任务"],
-        "acceptance_questions": ["能否解释候选队列依据？"],
-        "notes": "只读演示，不回写 ERP。",
+        "constraint_keys": [
+            "erp_transaction_authority",
+            "supplier_commitment_requires_evidence",
+            "high_risk_requires_human_confirmation",
+            "no_erp_writeback",
+        ],
+        "data_source_statuses": [
+            {"source_key": "erp_order_material", "status": "to_confirm"},
+            {"source_key": "supplier_commitment_feedback", "status": "to_confirm"},
+            {"source_key": "logistics_node_status", "status": "unavailable"},
+        ],
+        "desired_action_keys": [
+            "create_order_exception_review_task",
+            "assign_procurement_or_planning_owner",
+            "record_verdict_and_override_reason",
+        ],
+        "missing_required_fields": [],
     }
     value.update(overrides)
     return value
@@ -47,7 +64,8 @@ class FakeGateway:
 
 
 class RecognitionContractTest(unittest.TestCase):
-    def test_recognized_profile_uses_fixed_semantic_identity_and_safe_boundary(self) -> None:
+    def test_matched_candidate_reconstructs_frozen_profile(self) -> None:
+        expected = json.loads(EXAMPLE_PATH.read_text(encoding="utf-8"))
         gateway = FakeGateway(candidate())
 
         result = recognize_scenario("订单可能延期，请识别干预场景。", gateway)
@@ -56,33 +74,184 @@ class RecognitionContractTest(unittest.TestCase):
         self.assertEqual(len(result.source_text_sha256), 64)
         self.assertEqual(result.provider, "openai_compatible")
         self.assertEqual(result.model, "demo-model")
-        self.assertEqual(result.scenario.decision_key, "order_priority_intervention")
-        self.assertFalse(result.scenario.customer_data_available)
-        self.assertEqual(
-            [(item.role_key, item.semantic_key, item.object_label) for item in result.scenario.object_role_bindings],
-            [
-                ("customer_order", "order.primary", "客户订单"),
-                ("material", "material.required", "物料"),
-                ("supplier", "supplier.candidate", "供应商"),
-            ],
-        )
-        self.assertEqual(len(result.scenario.declared_bridges), 1)
-        self.assertEqual(result.scenario.declared_bridges[0].predicate, "REQUIRES")
-        self.assertEqual(result.scenario.readiness_declarations[0].status.value, "to_confirm")
+        self.assertEqual(result.scenario, ScenarioParameters.from_dict(expected))
         self.assertIn("订单可能延期", gateway.calls[0][1])
+        system_prompt = gateway.calls[0][0]
+        self.assertIn("scenario_intake_candidate.v1", system_prompt)
+        self.assertNotIn("additional_objects", system_prompt)
+        self.assertNotIn("acceptance_questions", result.candidate)
 
-    def test_candidate_must_match_exact_non_executable_contract(self) -> None:
-        invalid = candidate(score=0.9)
+    def test_candidate_rejects_extra_ontology_or_execution_fields(self) -> None:
+        for field in (
+            "objects",
+            "participants",
+            "constraints",
+            "data_sources",
+            "desired_actions",
+            "semantic_key",
+            "readiness_declarations",
+            "customer_data_available",
+            "rule",
+            "score",
+            "facts",
+            "action",
+        ):
+            with self.subTest(field=field), self.assertRaisesRegex(
+                RecognitionError, f"unexpected fields: {field}"
+            ):
+                recognize_scenario("订单异常", FakeGateway(candidate(**{field: []})))
 
-        with self.assertRaisesRegex(RecognitionError, "unexpected fields: score"):
-            recognize_scenario("订单异常", FakeGateway(invalid))
+    def test_controlled_keys_reject_unknown_and_duplicate_values(self) -> None:
+        cases = (
+            ("participant_keys", ["unknown_participant"], "unknown participant_keys"),
+            (
+                "constraint_keys",
+                ["erp_transaction_authority", "erp_transaction_authority"],
+                "duplicate constraint_keys",
+            ),
+            ("desired_action_keys", ["publish_queue"], "unknown desired_action_keys"),
+            (
+                "missing_required_fields",
+                ["business_decision"],
+                "unknown missing_required_fields",
+            ),
+        )
+        for field, value, message in cases:
+            with self.subTest(field=field), self.assertRaisesRegex(
+                RecognitionError, message
+            ):
+                recognize_scenario("订单异常", FakeGateway(candidate(**{field: value})))
 
-    def test_unsupported_profile_fails_loudly(self) -> None:
-        with self.assertRaisesRegex(RecognitionError, "unsupported profile"):
+    def test_data_source_statuses_are_strict_and_unique(self) -> None:
+        cases = (
+            (
+                [{"source_key": "unknown_source", "status": "to_confirm"}],
+                "unknown data source key",
+            ),
+            (
+                [{"source_key": "erp_order_material", "status": "confirmed"}],
+                "unsupported data source status",
+            ),
+            (
+                [
+                    {"source_key": "erp_order_material", "status": "available"},
+                    {"source_key": "erp_order_material", "status": "to_confirm"},
+                ],
+                "duplicate data source key",
+            ),
+            (
+                [
+                    {
+                        "source_key": "erp_order_material",
+                        "status": "to_confirm",
+                        "name": "模型自定义 ERP",
+                    }
+                ],
+                "must contain only source_key and status",
+            ),
+        )
+        for statuses, message in cases:
+            with self.subTest(message=message), self.assertRaisesRegex(
+                RecognitionError, message
+            ):
+                recognize_scenario(
+                    "订单异常",
+                    FakeGateway(candidate(data_source_statuses=statuses)),
+                )
+
+    def test_array_reordering_produces_stable_candidate_and_scenario(self) -> None:
+        original = candidate()
+        reordered = candidate(
+            participant_keys=list(reversed(original["participant_keys"])),
+            constraint_keys=list(reversed(original["constraint_keys"])),
+            data_source_statuses=list(reversed(original["data_source_statuses"])),
+            desired_action_keys=list(reversed(original["desired_action_keys"])),
+        )
+
+        first = recognize_scenario("订单异常", FakeGateway(original))
+        second = recognize_scenario("订单异常", FakeGateway(reordered))
+
+        self.assertEqual(first.candidate_json, second.candidate_json)
+        self.assertEqual(first.scenario, second.scenario)
+        self.assertEqual(
+            build_recognition_demo_envelope(first),
+            build_recognition_demo_envelope(second),
+        )
+
+    def test_unmentioned_data_sources_default_to_review(self) -> None:
+        result = recognize_scenario(
+            "订单异常",
+            FakeGateway(
+                candidate(
+                    data_source_statuses=[
+                        {"source_key": "logistics_node_status", "status": "unavailable"}
+                    ]
+                )
+            ),
+        )
+
+        self.assertEqual(
+            [source.status for source in result.scenario.data_sources],
+            ["to_confirm", "to_confirm", "unavailable"],
+        )
+
+    def test_insufficient_information_fails_without_profile_fallback(self) -> None:
+        with self.assertRaisesRegex(RecognitionError, "insufficient information"):
+            recognize_scenario(
+                "订单异常",
+                FakeGateway(
+                    candidate(
+                        match_status="insufficient_information",
+                        decision_owner=None,
+                        missing_required_fields=["decision_owner"],
+                    )
+                ),
+            )
+
+    def test_unsupported_fails_without_closest_profile_fallback(self) -> None:
+        with self.assertRaisesRegex(RecognitionError, "unsupported scenario"):
             recognize_scenario(
                 "请选择供应商",
-                FakeGateway(candidate(profile="supplier_selection")),
+                FakeGateway(
+                    candidate(
+                        match_status="unsupported",
+                        profile_key=None,
+                        decision_owner=None,
+                        trigger=None,
+                        participant_keys=[],
+                        constraint_keys=[],
+                        data_source_statuses=[],
+                        desired_action_keys=[],
+                    )
+                ),
             )
+
+    def test_matched_requires_complete_owner_trigger_and_no_missing_fields(self) -> None:
+        cases = (
+            ({"decision_owner": None}, "decision_owner is required"),
+            ({"trigger": None}, "trigger is required"),
+            (
+                {"missing_required_fields": ["trigger"]},
+                "matched candidate cannot have missing required fields",
+            ),
+            ({"profile_key": None}, "matched profile_key"),
+        )
+        for overrides, message in cases:
+            with self.subTest(overrides=overrides), self.assertRaisesRegex(
+                RecognitionError, message
+            ):
+                recognize_scenario("订单异常", FakeGateway(candidate(**overrides)))
+
+    def test_owner_and_trigger_are_bounded_extracted_text(self) -> None:
+        cases = (
+            ({"decision_owner": "责" * 81}, "decision_owner exceeds 80 characters"),
+            ({"trigger": "异" * 301}, "trigger exceeds 300 characters"),
+        )
+        for overrides, message in cases:
+            with self.subTest(overrides=overrides), self.assertRaisesRegex(
+                RecognitionError, message
+            ):
+                recognize_scenario("订单异常", FakeGateway(candidate(**overrides)))
 
     def test_model_response_must_be_a_json_object(self) -> None:
         class InvalidGateway:

--- a/tests/test_recognition_cli.py
+++ b/tests/test_recognition_cli.py
@@ -12,20 +12,16 @@ from ontology_poc_generator.recognition_cli import build_parser, main
 def candidate_content() -> str:
     return json.dumps(
         {
-            "schema": "scenario_recognition_candidate.v1",
-            "profile": "order_priority_intervention",
-            "industry": "制造业供应链",
-            "scene_name": "订单履约异常识别",
-            "business_decision": "哪些订单进入优先干预队列",
+            "schema": "scenario_intake_candidate.v1",
+            "match_status": "matched",
+            "profile_key": "order_priority_intervention",
             "decision_owner": "供应链计划经理",
             "trigger": "交期或物料齐套异常时",
-            "participants": ["订单经理"],
-            "additional_objects": ["订单行"],
-            "constraints": ["ERP 是交易事实权威"],
-            "data_sources": [],
-            "desired_actions": ["创建人工核查任务"],
-            "acceptance_questions": ["能否解释候选队列依据？"],
-            "notes": "只读演示",
+            "participant_keys": ["order_manager"],
+            "constraint_keys": ["erp_transaction_authority", "no_erp_writeback"],
+            "data_source_statuses": [],
+            "desired_action_keys": ["create_order_exception_review_task"],
+            "missing_required_fields": [],
         },
         ensure_ascii=False,
     )

--- a/tests/test_recognition_cli.py
+++ b/tests/test_recognition_cli.py
@@ -1,0 +1,125 @@
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from ontology_poc_generator.recognition import ModelCompletion
+from ontology_poc_generator.recognition_cli import build_parser, main
+
+
+def candidate_content() -> str:
+    return json.dumps(
+        {
+            "schema": "scenario_recognition_candidate.v1",
+            "profile": "order_priority_intervention",
+            "industry": "制造业供应链",
+            "scene_name": "订单履约异常识别",
+            "business_decision": "哪些订单进入优先干预队列",
+            "decision_owner": "供应链计划经理",
+            "trigger": "交期或物料齐套异常时",
+            "participants": ["订单经理"],
+            "additional_objects": ["订单行"],
+            "constraints": ["ERP 是交易事实权威"],
+            "data_sources": [],
+            "desired_actions": ["创建人工核查任务"],
+            "acceptance_questions": ["能否解释候选队列依据？"],
+            "notes": "只读演示",
+        },
+        ensure_ascii=False,
+    )
+
+
+class FakeGateway:
+    instances: list["FakeGateway"] = []
+
+    def __init__(self, **kwargs: object) -> None:
+        self.kwargs = kwargs
+        self.__class__.instances.append(self)
+
+    def complete_json(self, *, system_prompt: str, user_prompt: str) -> ModelCompletion:
+        return ModelCompletion("openai_compatible", "served-model", candidate_content())
+
+
+class RecognitionCliTest(unittest.TestCase):
+    def setUp(self) -> None:
+        FakeGateway.instances.clear()
+
+    def test_parser_does_not_accept_api_key_value(self) -> None:
+        option_strings = {
+            option
+            for action in build_parser()._actions
+            for option in action.option_strings
+        }
+        self.assertNotIn("--api-key", option_strings)
+        self.assertIn("--api-key-env", option_strings)
+
+    def test_cli_runs_model_and_writes_complete_closed_demo_atomically(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "scenario.txt"
+            output = root / "demo.json"
+            source.write_text("订单预计延期，需要识别人工干预场景。", encoding="utf-8")
+            environment = {
+                "DEMO_MODEL_KEY": "secret-value",
+                "EIP_MODEL_API_BASE": "https://models.example/v1",
+                "EIP_MODEL_NAME": "configured-model",
+            }
+
+            with patch.dict(os.environ, environment, clear=False), patch(
+                "ontology_poc_generator.recognition_cli.OpenAICompatibleGateway",
+                FakeGateway,
+            ):
+                exit_code = main(
+                    [str(source), "--api-key-env", "DEMO_MODEL_KEY", "--output", str(output)]
+                )
+
+            self.assertEqual(exit_code, 0)
+            envelope = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(envelope["schema"], "model_recognition_demo.v1")
+            self.assertEqual(envelope["recognition"]["model"], "served-model")
+            self.assertEqual(envelope["scenario"]["decision_key"], "order_priority_intervention")
+            self.assertFalse(envelope["scenario"]["customer_data_available"])
+            self.assertEqual(envelope["ontology_spec"]["compilation_status"], "complete")
+            self.assertTrue(envelope["ontology_spec"]["reference_closure"]["is_closed"])
+            self.assertEqual(FakeGateway.instances[0].kwargs["api_key"], "secret-value")
+            self.assertNotIn("secret-value", output.read_text(encoding="utf-8"))
+            self.assertEqual(list(root.glob(".*.tmp")), [])
+
+    def test_missing_model_configuration_is_input_error_without_output(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "scenario.txt"
+            output = root / "demo.json"
+            source.write_text("订单异常", encoding="utf-8")
+            with patch.dict(os.environ, {}, clear=True):
+                exit_code = main([str(source), "--output", str(output)])
+
+            self.assertEqual(exit_code, 2)
+            self.assertFalse(output.exists())
+
+    def test_output_failure_returns_three_and_leaves_no_partial_file(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "scenario.txt"
+            output = root / "demo.json"
+            source.write_text("订单异常", encoding="utf-8")
+            environment = {
+                "EIP_MODEL_API_KEY": "secret-value",
+                "EIP_MODEL_API_BASE": "https://models.example/v1",
+                "EIP_MODEL_NAME": "configured-model",
+            }
+            with patch.dict(os.environ, environment, clear=True), patch(
+                "ontology_poc_generator.recognition_cli.OpenAICompatibleGateway",
+                FakeGateway,
+            ), patch("ontology_poc_generator.recognition_cli.os.replace", side_effect=OSError("no space")):
+                exit_code = main([str(source), "--output", str(output)])
+
+            self.assertEqual(exit_code, 3)
+            self.assertFalse(output.exists())
+            self.assertEqual(list(root.glob(".*.tmp")), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_recognition_cli_safety.py
+++ b/tests/test_recognition_cli_safety.py
@@ -1,0 +1,105 @@
+import io
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from unittest.mock import patch
+
+from ontology_poc_generator.recognition_cli import main
+
+
+class RecognitionCliSafetyTest(unittest.TestCase):
+    def test_invalid_model_url_is_input_error_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "scenario.txt"
+            source.write_text("订单异常", encoding="utf-8")
+            stderr = io.StringIO()
+
+            with patch.dict(
+                os.environ,
+                {"EIP_MODEL_API_KEY": "secret-value"},
+                clear=True,
+            ), redirect_stderr(stderr):
+                exit_code = main(
+                    [
+                        str(source),
+                        "--api-base",
+                        "https://models.example/invalid\npath",
+                        "--model",
+                        "configured-model",
+                    ]
+                )
+
+            self.assertEqual(exit_code, 2)
+            self.assertIn("input error: model request failed", stderr.getvalue())
+            self.assertNotIn("Traceback", stderr.getvalue())
+
+    def test_output_resolving_to_input_is_rejected_before_model_call(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "scenario.txt"
+            output_alias = root / "demo.json"
+            original = "订单异常，需要识别干预场景。".encode("utf-8")
+            source.write_bytes(original)
+            output_alias.symlink_to(source)
+
+            with patch.dict(
+                os.environ,
+                {
+                    "EIP_MODEL_API_KEY": "secret-value",
+                    "EIP_MODEL_API_BASE": "https://models.example/v1",
+                    "EIP_MODEL_NAME": "configured-model",
+                },
+                clear=True,
+            ), patch(
+                "ontology_poc_generator.recognition_cli.OpenAICompatibleGateway",
+                side_effect=AssertionError("model must not be called"),
+            ):
+                exit_code = main([str(source), "--output", str(output_alias)])
+
+            self.assertEqual(exit_code, 3)
+            self.assertEqual(source.read_bytes(), original)
+            self.assertTrue(output_alias.is_symlink())
+
+    def test_case_aliased_knowledge_output_is_rejected_before_model_call(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "scenario.txt"
+            knowledge = root / "Policy.JSON"
+            output = root / "policy.json"
+            source.write_text("订单异常", encoding="utf-8")
+            original = b"preserve these knowledge bytes"
+            knowledge.write_bytes(original)
+
+            with patch.dict(
+                os.environ,
+                {
+                    "EIP_MODEL_API_KEY": "secret-value",
+                    "EIP_MODEL_API_BASE": "https://models.example/v1",
+                    "EIP_MODEL_NAME": "configured-model",
+                },
+                clear=True,
+            ), patch(
+                "ontology_poc_generator.recognition_cli.OpenAICompatibleGateway",
+                side_effect=AssertionError("model must not be called"),
+            ):
+                exit_code = main(
+                    [
+                        str(source),
+                        "--knowledge-unit",
+                        str(knowledge),
+                        "--output",
+                        str(output),
+                    ]
+                )
+
+            self.assertEqual(exit_code, 3)
+            self.assertEqual(knowledge.read_bytes(), original)
+            if output.exists():
+                self.assertTrue(output.samefile(knowledge))
+                self.assertEqual(output.read_bytes(), original)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add canonical DecisionPack CLI output without changing legacy proposal bytes
- recognize one controlled order-priority scenario through an OpenAI-compatible model gateway
- compile matched candidates into closed draft OntologySpec evidence while rejecting unsupported, incomplete, or unsafe fields
- guard malformed model URLs and input/output path collisions

## Verification
- focused unittest: 46/46
- full unittest: 230/230
- git diff --check
- synthetic gateway golden smoke: closed=true, complete, blocking=0
- independent review: no P1/P2

## Boundaries
- synthetic_demo / draft / candidate only
- no customer facts, queue verdicts, Action execution, publication, database, or external writeback
- no frontend changes