### PR TITLE
chore: rename project to ontopoc

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,13 +3,15 @@ requires = ["setuptools>=68"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "ontology-poc-generator"
+name = "ontopoc"
 version = "0.1.0"
 description = "Decision-centered ontology POC proposal generator"
 requires-python = ">=3.11"
 dependencies = []
 
 [project.scripts]
+ontopoc = "ontology_poc_generator.cli:main"
+ontopoc-recognize = "ontology_poc_generator.recognition_cli:main"
 ontology-poc = "ontology_poc_generator.cli:main"
 ontology-poc-recognize = "ontology_poc_generator.recognition_cli:main"
 

--- a/tests/test_project_identity.py
+++ b/tests/test_project_identity.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import tomllib
+import unittest
+
+
+PROJECT_FILE = Path(__file__).parents[1] / "pyproject.toml"
+
+
+class ProjectIdentityTest(unittest.TestCase):
+    def test_public_project_and_cli_names_are_ontopoc(self) -> None:
+        project = tomllib.loads(PROJECT_FILE.read_text(encoding="utf-8"))["project"]
+
+        self.assertEqual(project["name"], "ontopoc")
+        self.assertEqual(project["scripts"]["ontopoc"], "ontology_poc_generator.cli:main")
+        self.assertEqual(
+            project["scripts"]["ontopoc-recognize"],
+            "ontology_poc_generator.recognition_cli:main",
+        )
+
+    def test_legacy_cli_names_remain_as_compatibility_aliases(self) -> None:
+        scripts = tomllib.loads(PROJECT_FILE.read_text(encoding="utf-8"))["project"][
+            "scripts"
+        ]
+
+        self.assertEqual(scripts["ontology-poc"], scripts["ontopoc"])
+        self.assertEqual(
+            scripts["ontology-poc-recognize"], scripts["ontopoc-recognize"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- rename the Python distribution to `ontopoc`
- add `ontopoc` and `ontopoc-recognize` commands
- preserve the existing CLI names as compatibility aliases
- keep the internal Python package unchanged

## Verification
- focused unittest: 2/2
- full unittest: 232/232
- git diff --check
- wheel metadata and all four console scripts smoke-tested
- independent review: no P1/P2

## Scope
- no README, frontend, package-directory, or repository-slug rename in this PR