### PR TITLE
fix: ground recognized decision owner

### DIFF
--- a/src/ontology_poc_generator/recognition.py
+++ b/src/ontology_poc_generator/recognition.py
@@ -94,6 +94,7 @@ no_erp_writeback。data_source_statuses 每项只能包含 source_key 和 status
 create_order_exception_review_task、assign_procurement_or_planning_owner、
 record_verdict_and_override_reason。missing_required_fields 只能使用 decision_owner、trigger。
 
+decision_owner 必须逐字复制材料中的负责人称谓，不能输出 participant key 或自行改写。
 除 decision_owner 和 trigger 外，不要输出自由文本。不要输出对象、语义 ID、关系、
 readiness、customer data、规则、threshold、expression、score、weight、客户事实、
 队列结论、Action、发布状态或写回指令。
@@ -387,6 +388,9 @@ def recognize_scenario(
     except json.JSONDecodeError as exc:
         raise RecognitionError("model response must be a valid JSON object") from exc
     candidate = _validate_candidate(parsed)
+    decision_owner = candidate["decision_owner"]
+    if not isinstance(decision_owner, str) or decision_owner not in normalized_source:
+        raise RecognitionError("decision_owner must be copied from source text")
     scenario = _scenario_from_candidate(candidate)
     candidate_json = json.dumps(
         candidate,

--- a/tests/test_recognition.py
+++ b/tests/test_recognition.py
@@ -12,6 +12,7 @@ from ontology_poc_generator.models import ScenarioParameters
 
 
 EXAMPLE_PATH = Path(__file__).parents[1] / "examples" / "supply_chain_exception.json"
+MATCHED_SOURCE = "供应链计划经理负责判断哪些订单进入人工干预队列。"
 
 
 def candidate(**overrides: object) -> dict[str, object]:
@@ -68,14 +69,14 @@ class RecognitionContractTest(unittest.TestCase):
         expected = json.loads(EXAMPLE_PATH.read_text(encoding="utf-8"))
         gateway = FakeGateway(candidate())
 
-        result = recognize_scenario("订单可能延期，请识别干预场景。", gateway)
+        result = recognize_scenario(MATCHED_SOURCE, gateway)
 
         self.assertEqual(result.prompt_version, "order_priority_intervention.v1")
         self.assertEqual(len(result.source_text_sha256), 64)
         self.assertEqual(result.provider, "openai_compatible")
         self.assertEqual(result.model, "demo-model")
         self.assertEqual(result.scenario, ScenarioParameters.from_dict(expected))
-        self.assertIn("订单可能延期", gateway.calls[0][1])
+        self.assertIn("供应链计划经理", gateway.calls[0][1])
         system_prompt = gateway.calls[0][0]
         self.assertIn("scenario_intake_candidate.v1", system_prompt)
         self.assertNotIn("additional_objects", system_prompt)
@@ -168,8 +169,8 @@ class RecognitionContractTest(unittest.TestCase):
             desired_action_keys=list(reversed(original["desired_action_keys"])),
         )
 
-        first = recognize_scenario("订单异常", FakeGateway(original))
-        second = recognize_scenario("订单异常", FakeGateway(reordered))
+        first = recognize_scenario(MATCHED_SOURCE, FakeGateway(original))
+        second = recognize_scenario(MATCHED_SOURCE, FakeGateway(reordered))
 
         self.assertEqual(first.candidate_json, second.candidate_json)
         self.assertEqual(first.scenario, second.scenario)
@@ -180,7 +181,7 @@ class RecognitionContractTest(unittest.TestCase):
 
     def test_unmentioned_data_sources_default_to_review(self) -> None:
         result = recognize_scenario(
-            "订单异常",
+            MATCHED_SOURCE,
             FakeGateway(
                 candidate(
                     data_source_statuses=[
@@ -253,6 +254,16 @@ class RecognitionContractTest(unittest.TestCase):
             ):
                 recognize_scenario("订单异常", FakeGateway(candidate(**overrides)))
 
+    def test_decision_owner_must_be_copied_from_source_text(self) -> None:
+        with self.assertRaisesRegex(
+            RecognitionError,
+            "decision_owner must be copied from source text",
+        ):
+            recognize_scenario(
+                "供应链计划经理负责判断哪些订单进入人工干预队列。",
+                FakeGateway(candidate(decision_owner="production_planner")),
+            )
+
     def test_model_response_must_be_a_json_object(self) -> None:
         class InvalidGateway:
             def complete_json(self, *, system_prompt: str, user_prompt: str) -> ModelCompletion:
@@ -262,7 +273,7 @@ class RecognitionContractTest(unittest.TestCase):
             recognize_scenario("订单异常", InvalidGateway())
 
     def test_demo_envelope_compiles_closed_candidate_without_actions_or_facts(self) -> None:
-        result = recognize_scenario("订单异常", FakeGateway(candidate()))
+        result = recognize_scenario(MATCHED_SOURCE, FakeGateway(candidate()))
 
         envelope = build_recognition_demo_envelope(result)
 

--- a/tests/test_recognition_cli.py
+++ b/tests/test_recognition_cli.py
@@ -56,7 +56,10 @@ class RecognitionCliTest(unittest.TestCase):
             root = Path(directory)
             source = root / "scenario.txt"
             output = root / "demo.json"
-            source.write_text("订单预计延期，需要识别人工干预场景。", encoding="utf-8")
+            source.write_text(
+                "供应链计划经理负责识别需要人工干预的延期订单。",
+                encoding="utf-8",
+            )
             environment = {
                 "DEMO_MODEL_KEY": "secret-value",
                 "EIP_MODEL_API_BASE": "https://models.example/v1",
@@ -100,7 +103,10 @@ class RecognitionCliTest(unittest.TestCase):
             root = Path(directory)
             source = root / "scenario.txt"
             output = root / "demo.json"
-            source.write_text("订单异常", encoding="utf-8")
+            source.write_text(
+                "供应链计划经理负责识别需要人工干预的异常订单。",
+                encoding="utf-8",
+            )
             environment = {
                 "EIP_MODEL_API_KEY": "secret-value",
                 "EIP_MODEL_API_BASE": "https://models.example/v1",


### PR DESCRIPTION
## Summary
- require the recognized decision owner to be copied from the source text
- instruct the model not to emit participant keys or paraphrases as owner values
- preserve existing insufficient-information and unsupported behavior

## Verification
- focused unittest: 20/20
- full unittest: 233/233
- git diff --check
- live EIP configured-model smoke: owner=供应链计划经理, closed=true, complete, blocking=0
- independent review: no P1/P2

## Scope
- no new profile, facts, actions, frontend, database writes, or publication