### PR TITLE
feat: define validation receipt contract

### DIFF
--- a/src/ontology_poc_generator/validation_receipt.py
+++ b/src/ontology_poc_generator/validation_receipt.py
@@ -1,0 +1,165 @@
+from dataclasses import dataclass
+from enum import Enum
+import hashlib
+import json
+import re
+
+
+_SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+
+
+class ValidationReceiptValidationError(ValueError):
+    """A validation receipt violates the frozen local contract."""
+
+
+class EvaluationStatus(str, Enum):
+    PASS = "pass"
+    FAIL = "fail"
+    NOT_EVALUABLE = "not_evaluable"
+    UNSUPPORTED = "unsupported"
+
+
+class DecisionResult(str, Enum):
+    IN_QUEUE = "in_queue"
+    NOT_IN_QUEUE = "not_in_queue"
+    INFORMATION_INSUFFICIENT = "information_insufficient"
+    UNSUPPORTED = "unsupported"
+
+
+_RESULT_BY_STATUS = {
+    EvaluationStatus.PASS: DecisionResult.IN_QUEUE,
+    EvaluationStatus.FAIL: DecisionResult.NOT_IN_QUEUE,
+    EvaluationStatus.NOT_EVALUABLE: DecisionResult.INFORMATION_INSUFFICIENT,
+    EvaluationStatus.UNSUPPORTED: DecisionResult.UNSUPPORTED,
+}
+
+
+def _required_text(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationReceiptValidationError(f"{field} is required")
+    return value.strip()
+
+
+def _content_hash(value: object, field: str) -> str:
+    if not isinstance(value, str) or not _SHA256_PATTERN.fullmatch(value):
+        raise ValidationReceiptValidationError(
+            f"{field} must be a lowercase SHA-256 hex digest"
+        )
+    return value
+
+
+def _references(value: object, field: str) -> tuple[str, ...]:
+    if not isinstance(value, tuple) or not value:
+        raise ValidationReceiptValidationError(
+            f"{field} must be a non-empty tuple"
+        )
+    normalized = tuple(
+        _required_text(item, f"{field}[{index}]")
+        for index, item in enumerate(value)
+    )
+    if len(set(normalized)) != len(normalized):
+        raise ValidationReceiptValidationError(f"{field} must not contain duplicates")
+    return tuple(sorted(normalized))
+
+
+@dataclass(frozen=True)
+class ValidationReceipt:
+    schema: str
+    decision_pack_content_hash: str
+    ontology_spec_content_hash: str
+    facts_content_hash: str
+    rule_id: str
+    evaluation_status: EvaluationStatus
+    decision_result: DecisionResult
+    fact_refs: tuple[str, ...]
+    evidence_refs: tuple[str, ...]
+    draft_created: bool
+    published: bool
+    actions_executed: bool
+    external_write: bool
+
+    def __post_init__(self) -> None:
+        if self.schema != "validation_receipt.v1":
+            raise ValidationReceiptValidationError(
+                "schema must be validation_receipt.v1"
+            )
+        for field in (
+            "decision_pack_content_hash",
+            "ontology_spec_content_hash",
+            "facts_content_hash",
+        ):
+            object.__setattr__(
+                self,
+                field,
+                _content_hash(getattr(self, field), field),
+            )
+        object.__setattr__(self, "rule_id", _required_text(self.rule_id, "rule_id"))
+        if not isinstance(self.evaluation_status, EvaluationStatus):
+            raise ValidationReceiptValidationError(
+                "evaluation_status must be EvaluationStatus"
+            )
+        if not isinstance(self.decision_result, DecisionResult):
+            raise ValidationReceiptValidationError(
+                "decision_result must be DecisionResult"
+            )
+        expected_result = _RESULT_BY_STATUS[self.evaluation_status]
+        if self.decision_result is not expected_result:
+            raise ValidationReceiptValidationError(
+                "decision_result does not match evaluation_status"
+            )
+        object.__setattr__(self, "fact_refs", _references(self.fact_refs, "fact_refs"))
+        object.__setattr__(
+            self,
+            "evidence_refs",
+            _references(self.evidence_refs, "evidence_refs"),
+        )
+        for field in (
+            "draft_created",
+            "published",
+            "actions_executed",
+            "external_write",
+        ):
+            if getattr(self, field) is not False:
+                raise ValidationReceiptValidationError(
+                    f"{field} must be literal false"
+                )
+
+
+def validation_receipt_to_dict(receipt: ValidationReceipt) -> dict[str, object]:
+    """Return the explicit canonical content projection of a receipt."""
+    if not isinstance(receipt, ValidationReceipt):
+        raise ValidationReceiptValidationError(
+            "receipt must be a ValidationReceipt"
+        )
+    return {
+        "schema": receipt.schema,
+        "decision_pack_content_hash": receipt.decision_pack_content_hash,
+        "ontology_spec_content_hash": receipt.ontology_spec_content_hash,
+        "facts_content_hash": receipt.facts_content_hash,
+        "rule_id": receipt.rule_id,
+        "evaluation_status": receipt.evaluation_status.value,
+        "decision_result": receipt.decision_result.value,
+        "fact_refs": list(receipt.fact_refs),
+        "evidence_refs": list(receipt.evidence_refs),
+        "draft_created": receipt.draft_created,
+        "published": receipt.published,
+        "actions_executed": receipt.actions_executed,
+        "external_write": receipt.external_write,
+    }
+
+
+def canonical_validation_receipt_json(receipt: ValidationReceipt) -> str:
+    return json.dumps(
+        validation_receipt_to_dict(receipt),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def validation_receipt_content_hash(receipt: ValidationReceipt) -> str:
+    canonical = canonical_validation_receipt_json(receipt).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+canonical_validation_receipt_dict = validation_receipt_to_dict

--- a/tests/test_validation_receipt.py
+++ b/tests/test_validation_receipt.py
@@ -1,0 +1,236 @@
+import dataclasses
+from dataclasses import FrozenInstanceError
+import hashlib
+import json
+import unittest
+
+import ontology_poc_generator.validation_receipt as receipt_module
+from ontology_poc_generator.validation_receipt import (
+    DecisionResult,
+    EvaluationStatus,
+    ValidationReceipt,
+    ValidationReceiptValidationError,
+    canonical_validation_receipt_json,
+    validation_receipt_content_hash,
+    validation_receipt_to_dict,
+)
+
+
+PACK_HASH = "a" * 64
+SPEC_HASH = "b" * 64
+FACTS_HASH = "c" * 64
+
+
+def receipt_fixture(**overrides: object) -> ValidationReceipt:
+    values = {
+        "schema": "validation_receipt.v1",
+        "decision_pack_content_hash": PACK_HASH,
+        "ontology_spec_content_hash": SPEC_HASH,
+        "facts_content_hash": FACTS_HASH,
+        "rule_id": "rule_priority_queue",
+        "evaluation_status": EvaluationStatus.PASS,
+        "decision_result": DecisionResult.IN_QUEUE,
+        "fact_refs": ("fact_order_state", "fact_supplier_state"),
+        "evidence_refs": ("evidence_policy", "evidence_source_snapshot"),
+        "draft_created": False,
+        "published": False,
+        "actions_executed": False,
+        "external_write": False,
+    }
+    values.update(overrides)
+    return ValidationReceipt(**values)
+
+
+class ValidationReceiptContractTest(unittest.TestCase):
+    def test_validation_receipt_contract_exposes_canonical_api(self):
+        self.assertEqual(
+            {
+                "DecisionResult",
+                "EvaluationStatus",
+                "ValidationReceipt",
+                "ValidationReceiptValidationError",
+                "canonical_validation_receipt_json",
+                "validation_receipt_content_hash",
+                "validation_receipt_to_dict",
+            },
+            {
+                name
+                for name in (
+                    "DecisionResult",
+                    "EvaluationStatus",
+                    "ValidationReceipt",
+                    "ValidationReceiptValidationError",
+                    "canonical_validation_receipt_json",
+                    "validation_receipt_content_hash",
+                    "validation_receipt_to_dict",
+                )
+                if hasattr(receipt_module, name)
+            },
+        )
+
+    def test_enums_expose_only_the_four_frozen_states(self):
+        self.assertEqual(
+            tuple(item.value for item in EvaluationStatus),
+            (
+                "pass",
+                "fail",
+                "not_evaluable",
+                "unsupported",
+            ),
+        )
+        self.assertEqual(
+            tuple(item.value for item in DecisionResult),
+            (
+                "in_queue",
+                "not_in_queue",
+                "information_insufficient",
+                "unsupported",
+            ),
+        )
+        with self.assertRaises(ValueError):
+            EvaluationStatus("pending")
+        with self.assertRaises(ValueError):
+            DecisionResult("unknown")
+
+    def test_receipt_is_frozen_and_requires_enum_members(self):
+        self.assertTrue(dataclasses.is_dataclass(ValidationReceipt))
+        receipt = receipt_fixture()
+
+        with self.assertRaises(FrozenInstanceError):
+            receipt.rule_id = "changed"
+        with self.assertRaisesRegex(
+            ValidationReceiptValidationError, "evaluation_status"
+        ):
+            receipt_fixture(evaluation_status="pass")
+        with self.assertRaisesRegex(
+            ValidationReceiptValidationError, "decision_result"
+        ):
+            receipt_fixture(decision_result="in_queue")
+
+    def test_schema_is_exactly_validation_receipt_v1(self):
+        for schema in ("validation_receipt.v2", " validation_receipt.v1", ""):
+            with self.subTest(schema=schema), self.assertRaisesRegex(
+                ValidationReceiptValidationError, "schema"
+            ):
+                receipt_fixture(schema=schema)
+
+    def test_all_three_content_hash_bindings_require_strict_lowercase_sha256(self):
+        for field in (
+            "decision_pack_content_hash",
+            "ontology_spec_content_hash",
+            "facts_content_hash",
+        ):
+            for value in ("a" * 63, "A" * 64, "g" * 64, f"{'a' * 64} ", 7):
+                with self.subTest(field=field, value=value), self.assertRaisesRegex(
+                    ValidationReceiptValidationError, field
+                ):
+                    receipt_fixture(**{field: value})
+
+    def test_rule_and_reference_bindings_are_nonempty_unique_tuples(self):
+        with self.assertRaisesRegex(ValidationReceiptValidationError, "rule_id"):
+            receipt_fixture(rule_id=" ")
+
+        for field in ("fact_refs", "evidence_refs"):
+            for value in ([], (), ("",), ("same", "same")):
+                with self.subTest(field=field, value=value), self.assertRaisesRegex(
+                    ValidationReceiptValidationError, field
+                ):
+                    receipt_fixture(**{field: value})
+
+    def test_only_the_four_legal_status_result_pairs_are_accepted(self):
+        legal_pairs = {
+            EvaluationStatus.PASS: DecisionResult.IN_QUEUE,
+            EvaluationStatus.FAIL: DecisionResult.NOT_IN_QUEUE,
+            EvaluationStatus.NOT_EVALUABLE: DecisionResult.INFORMATION_INSUFFICIENT,
+            EvaluationStatus.UNSUPPORTED: DecisionResult.UNSUPPORTED,
+        }
+
+        for status, result in legal_pairs.items():
+            with self.subTest(status=status):
+                self.assertEqual(
+                    receipt_fixture(
+                        evaluation_status=status,
+                        decision_result=result,
+                    ).decision_result,
+                    result,
+                )
+
+        for status, legal_result in legal_pairs.items():
+            for result in DecisionResult:
+                if result is legal_result:
+                    continue
+                with self.subTest(status=status, result=result), self.assertRaisesRegex(
+                    ValidationReceiptValidationError, "decision_result"
+                ):
+                    receipt_fixture(
+                        evaluation_status=status,
+                        decision_result=result,
+                    )
+
+    def test_all_delivery_boundary_fields_are_required_to_be_literal_false(self):
+        for field in (
+            "draft_created",
+            "published",
+            "actions_executed",
+            "external_write",
+        ):
+            for value in (True, 0, None):
+                with self.subTest(field=field, value=value), self.assertRaisesRegex(
+                    ValidationReceiptValidationError, field
+                ):
+                    receipt_fixture(**{field: value})
+
+    def test_reference_order_does_not_change_canonical_bytes_or_content_hash(self):
+        first = receipt_fixture(
+            fact_refs=("fact_b", "fact_a"),
+            evidence_refs=("evidence_b", "evidence_a"),
+        )
+        second = receipt_fixture(
+            fact_refs=("fact_a", "fact_b"),
+            evidence_refs=("evidence_a", "evidence_b"),
+        )
+
+        self.assertEqual(first.fact_refs, ("fact_a", "fact_b"))
+        self.assertEqual(first.evidence_refs, ("evidence_a", "evidence_b"))
+        self.assertEqual(
+            canonical_validation_receipt_json(first),
+            canonical_validation_receipt_json(second),
+        )
+        self.assertEqual(
+            validation_receipt_content_hash(first),
+            validation_receipt_content_hash(second),
+        )
+
+    def test_canonical_projection_is_explicit_repeatable_and_content_hashed(self):
+        receipt = receipt_fixture(
+            fact_refs=("fact_b", "fact_a"),
+            evidence_refs=("evidence_b", "evidence_a"),
+        )
+        expected = {
+            "schema": "validation_receipt.v1",
+            "decision_pack_content_hash": PACK_HASH,
+            "ontology_spec_content_hash": SPEC_HASH,
+            "facts_content_hash": FACTS_HASH,
+            "rule_id": "rule_priority_queue",
+            "evaluation_status": "pass",
+            "decision_result": "in_queue",
+            "fact_refs": ["fact_a", "fact_b"],
+            "evidence_refs": ["evidence_a", "evidence_b"],
+            "draft_created": False,
+            "published": False,
+            "actions_executed": False,
+            "external_write": False,
+        }
+
+        canonical = canonical_validation_receipt_json(receipt)
+        self.assertEqual(validation_receipt_to_dict(receipt), expected)
+        self.assertEqual(json.loads(canonical), expected)
+        self.assertEqual(canonical, canonical_validation_receipt_json(receipt))
+        self.assertEqual(
+            validation_receipt_content_hash(receipt),
+            hashlib.sha256(canonical.encode("utf-8")).hexdigest(),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a frozen ValidationReceipt contract for the four validation states
- bind pack, spec, and facts hashes plus rule, fact, and evidence references
- enforce fixed status/result pairs and literal false delivery-boundary flags
- provide deterministic canonical JSON and content hashing

## Verification
- focused unittest: 10/10
- full unittest: 243/243
- git diff --check
- independent review: no P1/P2

## Scope
- contract only; no evaluator, facts runtime, database, network, Action, workflow, or DecisionDelta