### PR TITLE
ci: run unittest checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,21 @@
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  unittest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+      - run: PYTHONPATH=src python -m unittest discover -s tests -v


### PR DESCRIPTION
## Summary
- run the repository unittest suite on every pull request
- run the same check on pushes to main
- use read-only repository permissions and no publishing steps

## Local verification
- workflow YAML parsed successfully
- full unittest: 243/243
- git diff --check

## Scope
- test automation only; no build, release, deployment, secrets, or external writeback