### PR TITLE
fix: render ontology spec workspace

### DIFF
--- a/landing-page/src/OntologyWorkspace.jsx
+++ b/landing-page/src/OntologyWorkspace.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Background,
   BackgroundVariant,
@@ -21,7 +21,7 @@ import {
   X,
 } from "lucide-react";
 
-import { answerArtifactQuestion } from "./ontologyWorkspaceModel.js";
+import { answerArtifactQuestion, keepOntologySelection } from "./ontologyWorkspaceModel.js";
 
 const localCopy = {
   zh: {
@@ -374,6 +374,9 @@ export function OntologyWorkspace({ data, t, language }) {
   const chatTriggerRef = useRef(null);
   const drawerRef = useRef(null);
   const chatWasOpenRef = useRef(false);
+  const selectItem = useCallback((next) => {
+    setSelected((current) => keepOntologySelection(current, next));
+  }, []);
 
   const selectedItem = selected.kind === "node"
     ? workspace.nodes.find(({ id }) => id === selected.id)
@@ -449,7 +452,7 @@ export function OntologyWorkspace({ data, t, language }) {
       {view === "graph" ? (
         <div id="ontology-panel-graph" role="tabpanel" aria-labelledby="ontology-view-graph" className="ontology-graph-layout">
           <ReactFlowProvider>
-            <GraphCanvas workspace={workspace} selected={selected} onSelect={setSelected} copy={copy} />
+            <GraphCanvas workspace={workspace} selected={selected} onSelect={selectItem} copy={copy} />
           </ReactFlowProvider>
           <div className="ontology-inspector-shell">
             <EvidenceInspector item={selectedItem} copy={copy} onOpenChat={() => setChatOpen(true)} chatTriggerRef={chatTriggerRef} />

--- a/landing-page/src/ontologyWorkspaceModel.js
+++ b/landing-page/src/ontologyWorkspaceModel.js
@@ -439,6 +439,10 @@ export function projectOntologyWorkspace(input) {
   };
 }
 
+export function keepOntologySelection(current, next) {
+  return current.kind === next.kind && current.id === next.id ? current : next;
+}
+
 export function answerArtifactQuestion(question, workspace, language = "zh") {
   requireRecord(workspace, "ontology workspace");
   const text = typeof question === "string" ? question.trim() : "";

--- a/landing-page/src/ontologyWorkspaceModel.test.js
+++ b/landing-page/src/ontologyWorkspaceModel.test.js
@@ -4,6 +4,7 @@ import test from "node:test";
 
 import {
   answerArtifactQuestion,
+  keepOntologySelection,
   projectOntologyWorkspace,
 } from "./ontologyWorkspaceModel.js";
 
@@ -50,6 +51,16 @@ function resolveJsonPointer(value, pointer) {
     .map((part) => part.replaceAll("~1", "/").replaceAll("~0", "~"))
     .reduce((current, part) => current?.[part], value);
 }
+
+test("keeps the same selection reference to avoid a controlled graph update loop", () => {
+  const current = { kind: "node", id: "entity-1" };
+
+  assert.equal(keepOntologySelection(current, { kind: "node", id: "entity-1" }), current);
+  assert.deepEqual(
+    keepOntologySelection(current, { kind: "edge", id: "relation-1" }),
+    { kind: "edge", id: "relation-1" },
+  );
+});
 
 test("projects three entity nodes, three directed relation edges, and one distinct rule", () => {
   const workspace = projectOntologyWorkspace(artifact);

--- a/landing-page/src/styles.css
+++ b/landing-page/src/styles.css
@@ -29,7 +29,7 @@ a { color: inherit; text-decoration: none; }
 section[id] { scroll-margin-top: 78px; }
 
 .standalone-demo {
-  min-width: 1024px;
+  min-width: 0;
   height: 100vh;
   min-height: 680px;
   display: flex;
@@ -1385,6 +1385,23 @@ footer p:last-child { color: var(--muted); }
 }
 
 @media (max-width: 640px) {
+  .standalone-demo { width: 100%; height: auto; min-height: 100dvh; overflow: visible; }
+  .standalone-demo-header { min-height: 64px; grid-template-columns: minmax(0, 1fr) auto; gap: 12px; padding: 0 14px; }
+  .standalone-demo-brand { width: 128px; }
+  .standalone-demo-title,
+  .standalone-demo-actions > a { display: none; }
+  .standalone-demo-workspace { min-height: calc(100dvh - 64px); display: block; overflow: visible; }
+  .standalone-demo-workspace > * { min-height: calc(100dvh - 64px); }
+  .agent-review { overflow: visible; }
+  .agent-review-header { min-height: 108px; padding: 20px 14px; }
+  .agent-review-header h2 { font-size: 28px; }
+  .agent-review-layout { grid-template-columns: 1fr; overflow: visible; }
+  .agent-review-main { overflow: visible; padding: 16px 14px 24px; }
+  .agent-stage-list { grid-template-columns: 1fr 1fr; }
+  .agent-stage-list > div:nth-child(3) { border-left: 0; border-top: 1px solid var(--ink); }
+  .agent-stage-list > div:nth-child(4) { border-top: 1px solid var(--ink); }
+  .agent-candidate-groups { grid-template-columns: 1fr; }
+  .agent-review-aside { overflow: visible; border-top: 1px solid var(--ink); border-left: 0; }
   .site-header { height: 66px; padding: 0 18px; }
   .brand { width: 126px; }
   .header-actions { gap: 6px; }

--- a/landing-page/tests/landing-story.test.mjs
+++ b/landing-page/tests/landing-story.test.mjs
@@ -98,8 +98,11 @@ test("document modeling stays frontend-only and exposes no API POST or credentia
 });
 
 test("idle document modeler is PC-first and collapses without horizontal overflow", () => {
+  assert.match(styles, /\.standalone-demo\s*\{[^}]*min-width:\s*0/s);
+  assert.doesNotMatch(styles, /\.standalone-demo\s*\{[^}]*min-width:\s*1024px/s);
   assert.match(styles, /\.document-modeler\s*\{[^}]*grid-template-columns:\s*minmax\(0, 1fr\) minmax\(0, 1\.1fr\)/s);
   assert.match(styles, /@media \(max-width: 640px\)[\s\S]*\.document-modeler\s*\{[^}]*grid-template-columns:\s*1fr/s);
+  assert.match(styles, /@media \(max-width: 640px\)[\s\S]*\.standalone-demo-workspace\s*\{[^}]*overflow:\s*visible/s);
   assert.match(styles, /\.document-modeler\s*\{[^}]*min-width:\s*0/s);
 });
 


### PR DESCRIPTION
## Fix
- prevent controlled React Flow selection updates from re-entering the same state
- remove the standalone page minimum-width overflow
- stack the Agent review and compiler workspace at narrow window widths

## Reproduction verified
- 492px window: document to Agent review to OntologySpec Graph
- page scroll width equals viewport width
- four graph nodes render and the evidence inspector remains reachable
- no new Maximum update depth error

## Verification
- frontend unit: 58 passed
- Sites smoke: 4 passed
- backend unittest: 243 passed
- production build: 1973 modules