### PR TITLE
feat: evaluate synthetic decision rules

### DIFF
--- a/src/ontology_poc_generator/rule_runtime.py
+++ b/src/ontology_poc_generator/rule_runtime.py
@@ -39,9 +39,10 @@ def _references(value: object, field: str) -> tuple[str, ...]:
         _text(item, f"{field}[{index}]")
         for index, item in enumerate(value)
     )
-    if len(set(normalized)) != len(normalized):
+    normalized_keys = tuple(item.casefold() for item in normalized)
+    if len(set(normalized_keys)) != len(normalized_keys):
         raise RuleEvaluationError(f"{field} must not contain duplicates")
-    return tuple(sorted(normalized, key=str.casefold))
+    return tuple(sorted(normalized, key=lambda item: (item.casefold(), item)))
 
 
 @dataclass(frozen=True)
@@ -178,13 +179,9 @@ def evaluate_synthetic_rule(
     rule = rules[0]
 
     facts_by_property = {item.property_type_id: item for item in facts.facts}
-    condition_facts = []
+    condition_facts: list[SyntheticFact | None] = []
     for condition in rule.conditions:
         fact = facts_by_property.get(condition.property_type_id)
-        if fact is None:
-            raise RuleEvaluationError(
-                f"missing fact for property_type_id {condition.property_type_id}"
-            )
         condition_facts.append(fact)
 
     source_refs = _rule_source_refs(pack, rule.origin_suggestion_id)
@@ -195,6 +192,7 @@ def evaluate_synthetic_rule(
                 *(
                     evidence_ref
                     for fact in condition_facts
+                    if fact is not None
                     for evidence_ref in fact.evidence_refs
                 ),
             },
@@ -208,13 +206,13 @@ def evaluate_synthetic_rule(
         status = EvaluationStatus.UNSUPPORTED
         result = DecisionResult.UNSUPPORTED
     elif any(
-        fact.availability is FactAvailability.UNAVAILABLE
+        fact is None or fact.availability is FactAvailability.UNAVAILABLE
         for fact in condition_facts
     ):
         status = EvaluationStatus.NOT_EVALUABLE
         result = DecisionResult.INFORMATION_INSUFFICIENT
     elif all(
-        fact.value in condition.allowed_values
+        fact is not None and fact.value in condition.allowed_values
         for condition, fact in zip(rule.conditions, condition_facts, strict=True)
     ):
         status = EvaluationStatus.PASS
@@ -231,7 +229,16 @@ def evaluate_synthetic_rule(
         rule_id=rule.rule_id,
         evaluation_status=status,
         decision_result=result,
-        fact_refs=tuple(item.fact_ref for item in condition_facts),
+        fact_refs=tuple(
+            fact.fact_ref
+            if fact is not None
+            else f"missing:{facts.subject_id}:{condition.property_type_id}"
+            for condition, fact in zip(
+                rule.conditions,
+                condition_facts,
+                strict=True,
+            )
+        ),
         evidence_refs=evidence_refs,
         draft_created=False,
         published=False,

--- a/src/ontology_poc_generator/rule_runtime.py
+++ b/src/ontology_poc_generator/rule_runtime.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+import hashlib
+import json
+
+from ontology_poc_generator.decision_pack import (
+    DecisionPack,
+    decision_pack_content_hash,
+)
+from ontology_poc_generator.ontology_spec import SpecCompilationResult
+from ontology_poc_generator.validation_receipt import (
+    DecisionResult,
+    EvaluationStatus,
+    ValidationReceipt,
+)
+
+
+class RuleEvaluationError(ValueError):
+    """Synthetic facts or a compiled rule cannot form a bounded receipt."""
+
+
+class FactAvailability(str, Enum):
+    AVAILABLE = "available"
+    UNAVAILABLE = "unavailable"
+
+
+def _text(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise RuleEvaluationError(f"{field} is required")
+    return value.strip()
+
+
+def _references(value: object, field: str) -> tuple[str, ...]:
+    if not isinstance(value, tuple) or not value:
+        raise RuleEvaluationError(f"{field} must be a non-empty tuple")
+    normalized = tuple(
+        _text(item, f"{field}[{index}]")
+        for index, item in enumerate(value)
+    )
+    if len(set(normalized)) != len(normalized):
+        raise RuleEvaluationError(f"{field} must not contain duplicates")
+    return tuple(sorted(normalized, key=str.casefold))
+
+
+@dataclass(frozen=True)
+class SyntheticFact:
+    fact_ref: str
+    property_type_id: str
+    availability: FactAvailability
+    value: str | None
+    evidence_refs: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "fact_ref", _text(self.fact_ref, "fact_ref"))
+        object.__setattr__(
+            self,
+            "property_type_id",
+            _text(self.property_type_id, "property_type_id"),
+        )
+        if not isinstance(self.availability, FactAvailability):
+            raise RuleEvaluationError("availability must be FactAvailability")
+        if self.availability is FactAvailability.AVAILABLE:
+            object.__setattr__(self, "value", _text(self.value, "value"))
+        elif self.value is not None:
+            raise RuleEvaluationError("value must be absent when fact is unavailable")
+        object.__setattr__(
+            self,
+            "evidence_refs",
+            _references(self.evidence_refs, "evidence_refs"),
+        )
+
+
+@dataclass(frozen=True)
+class SyntheticFactSet:
+    schema: str
+    evidence_scope: str
+    subject_id: str
+    facts: tuple[SyntheticFact, ...]
+
+    def __post_init__(self) -> None:
+        if self.schema != "synthetic_fact_set.v1":
+            raise RuleEvaluationError("schema must be synthetic_fact_set.v1")
+        if self.evidence_scope != "synthetic_demo":
+            raise RuleEvaluationError("evidence_scope must be synthetic_demo")
+        object.__setattr__(self, "subject_id", _text(self.subject_id, "subject_id"))
+        if not isinstance(self.facts, tuple) or not self.facts:
+            raise RuleEvaluationError("facts must be a non-empty tuple")
+        if any(not isinstance(item, SyntheticFact) for item in self.facts):
+            raise RuleEvaluationError("facts must contain only SyntheticFact")
+        fact_refs = tuple(item.fact_ref.casefold() for item in self.facts)
+        property_ids = tuple(item.property_type_id.casefold() for item in self.facts)
+        if len(set(fact_refs)) != len(fact_refs):
+            raise RuleEvaluationError("facts must not repeat fact_ref")
+        if len(set(property_ids)) != len(property_ids):
+            raise RuleEvaluationError("facts must not repeat property_type_id")
+        object.__setattr__(
+            self,
+            "facts",
+            tuple(sorted(self.facts, key=lambda item: item.property_type_id.casefold())),
+        )
+
+
+def synthetic_fact_set_to_dict(facts: SyntheticFactSet) -> dict[str, object]:
+    if not isinstance(facts, SyntheticFactSet):
+        raise RuleEvaluationError("facts must be a SyntheticFactSet")
+    return {
+        "schema": facts.schema,
+        "evidence_scope": facts.evidence_scope,
+        "subject_id": facts.subject_id,
+        "facts": [
+            {
+                "fact_ref": item.fact_ref,
+                "property_type_id": item.property_type_id,
+                "availability": item.availability.value,
+                "value": item.value,
+                "evidence_refs": list(item.evidence_refs),
+            }
+            for item in facts.facts
+        ],
+    }
+
+
+def canonical_synthetic_fact_set_json(facts: SyntheticFactSet) -> str:
+    return json.dumps(
+        synthetic_fact_set_to_dict(facts),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def synthetic_fact_set_content_hash(facts: SyntheticFactSet) -> str:
+    canonical = canonical_synthetic_fact_set_json(facts).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _rule_source_refs(pack: DecisionPack, suggestion_id: str) -> tuple[str, ...]:
+    matches = [
+        suggestion
+        for outcome in pack.knowledge_outcomes
+        for suggestion in outcome.suggestions
+        if suggestion.suggestion_id == suggestion_id
+    ]
+    if len(matches) != 1:
+        raise RuleEvaluationError(
+            "rule origin_suggestion_id must resolve exactly once in DecisionPack"
+        )
+    return matches[0].source_ref_ids
+
+
+def evaluate_synthetic_rule(
+    pack: DecisionPack,
+    compilation: SpecCompilationResult,
+    facts: SyntheticFactSet,
+    rule_id: str,
+) -> ValidationReceipt:
+    if not isinstance(pack, DecisionPack):
+        raise RuleEvaluationError("pack must be a DecisionPack")
+    if not isinstance(compilation, SpecCompilationResult):
+        raise RuleEvaluationError("compilation must be a SpecCompilationResult")
+    if not isinstance(facts, SyntheticFactSet):
+        raise RuleEvaluationError("facts must be a SyntheticFactSet")
+    normalized_rule_id = _text(rule_id, "rule_id")
+
+    pack_hash = decision_pack_content_hash(pack)
+    if compilation.spec.pack_content_hash != pack_hash:
+        raise RuleEvaluationError("spec pack_content_hash does not match DecisionPack")
+
+    rules = [
+        item
+        for item in compilation.spec.rule_declarations
+        if item.rule_id == normalized_rule_id
+    ]
+    if len(rules) != 1:
+        raise RuleEvaluationError("rule_id must resolve exactly once")
+    rule = rules[0]
+
+    facts_by_property = {item.property_type_id: item for item in facts.facts}
+    condition_facts = []
+    for condition in rule.conditions:
+        fact = facts_by_property.get(condition.property_type_id)
+        if fact is None:
+            raise RuleEvaluationError(
+                f"missing fact for property_type_id {condition.property_type_id}"
+            )
+        condition_facts.append(fact)
+
+    source_refs = _rule_source_refs(pack, rule.origin_suggestion_id)
+    evidence_refs = tuple(
+        sorted(
+            {
+                *source_refs,
+                *(
+                    evidence_ref
+                    for fact in condition_facts
+                    for evidence_ref in fact.evidence_refs
+                ),
+            },
+            key=str.casefold,
+        )
+    )
+
+    if rule.rule_kind != "categorical_all_of_v1" or any(
+        condition.operator != "in" for condition in rule.conditions
+    ):
+        status = EvaluationStatus.UNSUPPORTED
+        result = DecisionResult.UNSUPPORTED
+    elif any(
+        fact.availability is FactAvailability.UNAVAILABLE
+        for fact in condition_facts
+    ):
+        status = EvaluationStatus.NOT_EVALUABLE
+        result = DecisionResult.INFORMATION_INSUFFICIENT
+    elif all(
+        fact.value in condition.allowed_values
+        for condition, fact in zip(rule.conditions, condition_facts, strict=True)
+    ):
+        status = EvaluationStatus.PASS
+        result = DecisionResult.IN_QUEUE
+    else:
+        status = EvaluationStatus.FAIL
+        result = DecisionResult.NOT_IN_QUEUE
+
+    return ValidationReceipt(
+        schema="validation_receipt.v1",
+        decision_pack_content_hash=pack_hash,
+        ontology_spec_content_hash=compilation.spec_content_hash,
+        facts_content_hash=synthetic_fact_set_content_hash(facts),
+        rule_id=rule.rule_id,
+        evaluation_status=status,
+        decision_result=result,
+        fact_refs=tuple(item.fact_ref for item in condition_facts),
+        evidence_refs=evidence_refs,
+        draft_created=False,
+        published=False,
+        actions_executed=False,
+        external_write=False,
+    )

--- a/tests/test_rule_runtime.py
+++ b/tests/test_rule_runtime.py
@@ -1,0 +1,232 @@
+import dataclasses
+import importlib
+import json
+import unittest
+from pathlib import Path
+
+from ontology_poc_generator.compiler import compile_decision_pack
+from ontology_poc_generator.decision_pack import decision_pack_content_hash
+from ontology_poc_generator.knowledge import load_knowledge_unit
+from ontology_poc_generator.ontology_spec import SpecCompilationResult
+from ontology_poc_generator.spec_compiler import compile_ontology_spec
+from ontology_poc_generator.validation_receipt import (
+    DecisionResult,
+    EvaluationStatus,
+)
+from tests.test_decision_pack import minimal_scenario
+
+
+ROOT = Path(__file__).parents[1]
+BASELINE_POLICY = (
+    ROOT / "knowledge/supply_chain/order_priority_policy_synthetic_s1_v1.json"
+)
+CANDIDATE_POLICY = (
+    ROOT / "tests/fixtures/knowledge/order_priority_policy_synthetic_candidate_v2.json"
+)
+CASES_PATH = ROOT / "tests/fixtures/policy/order_priority_policy_synthetic_cases_v1.json"
+
+
+def runtime_module():
+    try:
+        return importlib.import_module("ontology_poc_generator.rule_runtime")
+    except ModuleNotFoundError:
+        raise AssertionError("rule_runtime module is not implemented") from None
+
+
+def compiled_policy(path: Path):
+    pack = compile_decision_pack(
+        minimal_scenario(),
+        (load_knowledge_unit(path),),
+    )
+    return pack, compile_ontology_spec(pack)
+
+
+def synthetic_facts(compilation, case):
+    runtime = runtime_module()
+    properties = {
+        item.semantic_key: item.property_type_id
+        for item in compilation.spec.property_types
+    }
+    values = []
+    for semantic_key, raw in case["inputs"].items():
+        values.append(
+            runtime.SyntheticFact(
+                fact_ref=f"{case['subject_id']}:{semantic_key}",
+                property_type_id=properties[semantic_key],
+                availability=runtime.FactAvailability(raw["availability"]),
+                value=raw.get("value"),
+                evidence_refs=(f"evidence:{case['subject_id']}:{semantic_key}",),
+            )
+        )
+    return runtime.SyntheticFactSet(
+        schema="synthetic_fact_set.v1",
+        evidence_scope="synthetic_demo",
+        subject_id=case["subject_id"],
+        facts=tuple(values),
+    )
+
+
+class RuleRuntimeTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.cases = json.loads(CASES_PATH.read_text(encoding="utf-8"))["cases"]
+
+    def test_four_synthetic_cases_produce_bound_baseline_and_candidate_receipts(self):
+        runtime = runtime_module()
+        baseline_pack, baseline = compiled_policy(BASELINE_POLICY)
+        candidate_pack, candidate = compiled_policy(CANDIDATE_POLICY)
+
+        self.assertEqual(
+            baseline.spec.rule_declarations[0].rule_id,
+            candidate.spec.rule_declarations[0].rule_id,
+        )
+
+        for case in self.cases:
+            for label, pack, compilation in (
+                ("baseline", baseline_pack, baseline),
+                ("candidate", candidate_pack, candidate),
+            ):
+                with self.subTest(subject=case["subject_id"], version=label):
+                    facts = synthetic_facts(compilation, case)
+                    receipt = runtime.evaluate_synthetic_rule(
+                        pack,
+                        compilation,
+                        facts,
+                        compilation.spec.rule_declarations[0].rule_id,
+                    )
+                    expected = case["expected"][label]
+
+                    self.assertIs(
+                        receipt.evaluation_status,
+                        EvaluationStatus(expected["evaluation_status"]),
+                    )
+                    self.assertIs(
+                        receipt.decision_result,
+                        DecisionResult(expected["conclusion_value"]),
+                    )
+                    self.assertEqual(
+                        receipt.decision_pack_content_hash,
+                        decision_pack_content_hash(pack),
+                    )
+                    self.assertEqual(
+                        receipt.ontology_spec_content_hash,
+                        compilation.spec_content_hash,
+                    )
+                    self.assertEqual(
+                        receipt.facts_content_hash,
+                        runtime.synthetic_fact_set_content_hash(facts),
+                    )
+                    self.assertEqual(
+                        receipt.rule_id,
+                        compilation.spec.rule_declarations[0].rule_id,
+                    )
+                    self.assertEqual(
+                        set(receipt.fact_refs),
+                        {item.fact_ref for item in facts.facts},
+                    )
+                    self.assertIn(
+                        "synthetic_order_priority_policy_cases_v1",
+                        receipt.evidence_refs,
+                    )
+                    self.assertFalse(receipt.draft_created)
+                    self.assertFalse(receipt.published)
+                    self.assertFalse(receipt.actions_executed)
+                    self.assertFalse(receipt.external_write)
+
+    def test_candidate_changes_only_the_at_risk_case_from_fail_to_pass(self):
+        runtime = runtime_module()
+        baseline_pack, baseline = compiled_policy(BASELINE_POLICY)
+        candidate_pack, candidate = compiled_policy(CANDIDATE_POLICY)
+        case = self.cases[1]
+
+        baseline_receipt = runtime.evaluate_synthetic_rule(
+            baseline_pack,
+            baseline,
+            synthetic_facts(baseline, case),
+            baseline.spec.rule_declarations[0].rule_id,
+        )
+        candidate_receipt = runtime.evaluate_synthetic_rule(
+            candidate_pack,
+            candidate,
+            synthetic_facts(candidate, case),
+            candidate.spec.rule_declarations[0].rule_id,
+        )
+
+        self.assertIs(baseline_receipt.evaluation_status, EvaluationStatus.FAIL)
+        self.assertIs(candidate_receipt.evaluation_status, EvaluationStatus.PASS)
+        self.assertNotEqual(
+            baseline_receipt.ontology_spec_content_hash,
+            candidate_receipt.ontology_spec_content_hash,
+        )
+
+    def test_unknown_rule_kind_returns_unsupported_without_execution(self):
+        runtime = runtime_module()
+        pack, compilation = compiled_policy(BASELINE_POLICY)
+        rule = dataclasses.replace(
+            compilation.spec.rule_declarations[0],
+            rule_kind="rolling_probability_v1",
+        )
+        unsupported = SpecCompilationResult(
+            spec=dataclasses.replace(
+                compilation.spec,
+                rule_declarations=(rule,),
+            ),
+            closure_report=compilation.closure_report,
+        )
+
+        receipt = runtime.evaluate_synthetic_rule(
+            pack,
+            unsupported,
+            synthetic_facts(unsupported, self.cases[0]),
+            rule.rule_id,
+        )
+
+        self.assertIs(receipt.evaluation_status, EvaluationStatus.UNSUPPORTED)
+        self.assertIs(receipt.decision_result, DecisionResult.UNSUPPORTED)
+        self.assertFalse(receipt.actions_executed)
+        self.assertFalse(receipt.external_write)
+
+    def test_fact_contract_rejects_non_synthetic_or_incoherent_values(self):
+        runtime = runtime_module()
+        fact = runtime.SyntheticFact(
+            fact_ref="fact-1",
+            property_type_id="property-1",
+            availability=runtime.FactAvailability.AVAILABLE,
+            value="missed",
+            evidence_refs=("evidence-1",),
+        )
+
+        for changes, message in (
+            ({"availability": runtime.FactAvailability.UNAVAILABLE}, "value"),
+            ({"value": None}, "value"),
+        ):
+            with self.subTest(changes=changes), self.assertRaisesRegex(
+                runtime.RuleEvaluationError,
+                message,
+            ):
+                dataclasses.replace(fact, **changes)
+
+        with self.assertRaisesRegex(runtime.RuleEvaluationError, "evidence_scope"):
+            runtime.SyntheticFactSet(
+                schema="synthetic_fact_set.v1",
+                evidence_scope="customer_data",
+                subject_id="order-1",
+                facts=(fact,),
+            )
+
+    def test_pack_and_spec_hash_mismatch_is_rejected(self):
+        runtime = runtime_module()
+        baseline_pack, _ = compiled_policy(BASELINE_POLICY)
+        _, candidate = compiled_policy(CANDIDATE_POLICY)
+
+        with self.assertRaisesRegex(runtime.RuleEvaluationError, "pack_content_hash"):
+            runtime.evaluate_synthetic_rule(
+                baseline_pack,
+                candidate,
+                synthetic_facts(candidate, self.cases[0]),
+                candidate.spec.rule_declarations[0].rule_id,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rule_runtime.py
+++ b/tests/test_rule_runtime.py
@@ -214,6 +214,47 @@ class RuleRuntimeTest(unittest.TestCase):
                 facts=(fact,),
             )
 
+        with self.assertRaisesRegex(runtime.RuleEvaluationError, "evidence_refs"):
+            dataclasses.replace(
+                fact,
+                evidence_refs=("Evidence-1", "evidence-1"),
+            )
+
+    def test_missing_required_fact_returns_not_evaluable_with_stable_reference(self):
+        runtime = runtime_module()
+        pack, compilation = compiled_policy(BASELINE_POLICY)
+        complete_facts = synthetic_facts(compilation, self.cases[0])
+        incomplete_facts = dataclasses.replace(
+            complete_facts,
+            facts=(complete_facts.facts[0],),
+        )
+        rule = compilation.spec.rule_declarations[0]
+        missing_property_id = next(
+            condition.property_type_id
+            for condition in rule.conditions
+            if condition.property_type_id != incomplete_facts.facts[0].property_type_id
+        )
+
+        receipt = runtime.evaluate_synthetic_rule(
+            pack,
+            compilation,
+            incomplete_facts,
+            rule.rule_id,
+        )
+
+        self.assertIs(
+            receipt.evaluation_status,
+            EvaluationStatus.NOT_EVALUABLE,
+        )
+        self.assertIs(
+            receipt.decision_result,
+            DecisionResult.INFORMATION_INSUFFICIENT,
+        )
+        self.assertIn(
+            f"missing:{incomplete_facts.subject_id}:{missing_property_id}",
+            receipt.fact_refs,
+        )
+
     def test_pack_and_spec_hash_mismatch_is_rejected(self):
         runtime = runtime_module()
         baseline_pack, _ = compiled_policy(BASELINE_POLICY)


### PR DESCRIPTION
## Summary
- add immutable in-memory synthetic fact contracts and canonical facts hashing
- evaluate categorical_all_of_v1 as pass, fail, not_evaluable, or unsupported
- emit ValidationReceipt bindings for pack, spec, facts, rule, fact, and evidence references
- preserve zero-side-effect flags and stable missing-input references

## Verification
- focused: 6 tests passed
- full: 249 tests passed
- git diff --check passed
- independent review: no remaining P1/P2 issues