### PR TITLE
docs: remove local absolute paths from public docs

### DIFF
--- a/docs/DEVELOPMENT_HANDOFF.md
+++ b/docs/DEVELOPMENT_HANDOFF.md
@@ -9,7 +9,7 @@
 
 仓库：`https://github.com/Longado/ontopoc`
 
-开发工作树：`/Users/eddie/Desktop/Workspace/ontology-poc-generator/.worktrees/pc-agent-modeling-demo`
+开发工作树：`.worktrees/pc-agent-modeling-demo`
 
 分支：`rico/handoff-v2`
 
@@ -27,7 +27,7 @@ PR：[#12 feat: add five-system multi-agent quality assessment](https://github.c
 恢复开发前运行：
 
 ```bash
-cd /Users/eddie/Desktop/Workspace/ontology-poc-generator/.worktrees/pc-agent-modeling-demo
+cd .worktrees/pc-agent-modeling-demo
 git status --short --branch
 git rev-parse HEAD
 git merge-base --is-ancestor 61df67b HEAD
@@ -318,7 +318,7 @@ npm run build
 
 ```text
 接手 OntoPoc 前，先完整阅读：
-/Users/eddie/Desktop/Workspace/ontology-poc-generator/.worktrees/pc-agent-modeling-demo/docs/DEVELOPMENT_HANDOFF.md
+docs/DEVELOPMENT_HANDOFF.md
 
 当前功能开发已经冻结。先执行第 0 节对账，确认 branch、HEAD、PR 和 CI；不要把文档快照当成实时状态。
 

--- a/docs/superpowers/plans/2026-09-01-gate1-real-material-signal.md
+++ b/docs/superpowers/plans/2026-09-01-gate1-real-material-signal.md
@@ -32,7 +32,7 @@
 
 **Local-sensitive artifact created during execution:**
 
-`/Users/eddie/Desktop/Workspace/.local-sensitive/ontology-poc-generator/experiments/2026-09-02-gate1-quality-control-evidence.json`
+`<workspace>/.local-sensitive/ontology-poc-generator/experiments/2026-09-02-gate1-quality-control-evidence.json`
 
 **Proof**
 
@@ -44,7 +44,7 @@
 
 ## Fixed comparison inputs
 
-- Negative: `/Users/eddie/Desktop/Workspace/ontology-poc-generator/.worktrees/pc-agent-modeling-demo/examples/dairy_rnd.json`
+- Negative: `examples/dairy_rnd.json`
 - Synthetic control (`source_kind=inline_synthetic`; exact UTF-8 text, no trailing newline): `某组件在终检中出现泄漏率异常，原因尚未确认。质量负责人决定将使用批次 B-17 的在制品和待发运件列入临时复检队列；已发运件因客户项目映射缺失暂不能判断。`
 - Fixed object labels used only for novelty comparison: `质量信号`、`受影响对象`、`质量证据`、`临时控制任务`
 - Fixed bridge used only for novelty comparison: `质量信号 → MAY_AFFECT → 受影响对象`
@@ -95,14 +95,14 @@
 **Files:**
 
 - Read: active execution-state relay in the current conversation
-- Read: user-selected positive source under `/Users/eddie/Desktop/Workspace/.local-sensitive/`
+- Read: user-selected positive source under `<workspace>/.local-sensitive/`
 - Modify: none
 
 - [ ] **Step 1: Confirm the five required values are explicit**
 
 The active relay must contain all five values:
 
-1. exact positive UTF-8 text or Markdown source path under `/Users/eddie/Desktop/Workspace/.local-sensitive/`;
+1. exact positive UTF-8 text or Markdown source path under `<workspace>/.local-sensitive/`;
 2. exact approved provider, model name and model settings; use `provider_default` when the approved interface exposes no setting controls;
 3. approval for exactly three model calls;
 4. five manual judgment bullets plus elapsed minutes, written before model output is shown.
@@ -115,7 +115,7 @@ If any value is absent, stop. Report only the missing value; do not create the e
 Run:
 
 ```bash
-cd /Users/eddie/Desktop/Workspace/ontology-poc-generator/.worktrees/pc-agent-modeling-demo
+cd .worktrees/pc-agent-modeling-demo
 git status --short --branch
 git rev-parse HEAD
 ```
@@ -126,7 +126,7 @@ Expected: branch `rico/handoff-v2`, no modified or untracked files before the ex
 
 Confirm the resolved positive source path starts with:
 
-`/Users/eddie/Desktop/Workspace/.local-sensitive/`
+`<workspace>/.local-sensitive/`
 
 If it resolves inside any git repository, `.data`, or the OntoPoc worktree, stop and request a safe copy under `.local-sensitive/`.
 
@@ -139,14 +139,14 @@ Confirm the source is already a redacted UTF-8 text or Markdown file describing 
 - Read: user-selected positive source
 - Read: `examples/dairy_rnd.json`
 - Use: the exact inline synthetic control text fixed in this plan
-- Create: `/Users/eddie/Desktop/Workspace/.local-sensitive/ontology-poc-generator/experiments/2026-09-02-gate1-quality-control-evidence.json`
+- Create: `<workspace>/.local-sensitive/ontology-poc-generator/experiments/2026-09-02-gate1-quality-control-evidence.json`
 
 - [ ] **Step 1: Create the evidence directory**
 
 Run:
 
 ```bash
-mkdir -p /Users/eddie/Desktop/Workspace/.local-sensitive/ontology-poc-generator/experiments
+mkdir -p <workspace>/.local-sensitive/ontology-poc-generator/experiments
 ```
 
 - [ ] **Step 2: Hash all three exact inputs**
@@ -179,7 +179,7 @@ Because this file contains customer text, use `apply_patch` and keep it only und
 
 **Files:**
 
-- Modify: `/Users/eddie/Desktop/Workspace/.local-sensitive/ontology-poc-generator/experiments/2026-09-02-gate1-quality-control-evidence.json`
+- Modify: `<workspace>/.local-sensitive/ontology-poc-generator/experiments/2026-09-02-gate1-quality-control-evidence.json`
 - Modify in repository: none
 
 - [ ] **Step 1: Run the positive case once**
@@ -202,7 +202,7 @@ Confirm exactly three model calls were made. Do not retry malformed output or ch
 
 **Files:**
 
-- Modify: `/Users/eddie/Desktop/Workspace/.local-sensitive/ontology-poc-generator/experiments/2026-09-02-gate1-quality-control-evidence.json`
+- Modify: `<workspace>/.local-sensitive/ontology-poc-generator/experiments/2026-09-02-gate1-quality-control-evidence.json`
 - Modify in repository: none
 
 - [ ] **Step 1: Validate the evidence record structure**
@@ -227,7 +227,7 @@ jq -e '
   )
   and (.manual_baseline.bullets | length == 5)
   and (.manual_baseline.elapsed_minutes > 0)
-' /Users/eddie/Desktop/Workspace/.local-sensitive/ontology-poc-generator/experiments/2026-09-02-gate1-quality-control-evidence.json
+' <workspace>/.local-sensitive/ontology-poc-generator/experiments/2026-09-02-gate1-quality-control-evidence.json
 ```
 
 Expected: `true`, exit 0.
@@ -245,7 +245,7 @@ jq -e '
     and all((.parsed_output.extracted_relations // [])[];
         .evidence_span as $span | $source | contains($span))
   )
-' /Users/eddie/Desktop/Workspace/.local-sensitive/ontology-poc-generator/experiments/2026-09-02-gate1-quality-control-evidence.json
+' <workspace>/.local-sensitive/ontology-poc-generator/experiments/2026-09-02-gate1-quality-control-evidence.json
 ```
 
 Expected: `true`, exit 0. Any false or malformed case yields `no_go`; do not repair the model output.
@@ -279,7 +279,7 @@ Otherwise set it to `no_go`. Record the failed condition IDs and a short factual
 Run:
 
 ```bash
-cd /Users/eddie/Desktop/Workspace/ontology-poc-generator/.worktrees/pc-agent-modeling-demo
+cd .worktrees/pc-agent-modeling-demo
 git status --short --branch
 ```
 

--- a/docs/superpowers/plans/2026-09-02-end-to-end-multi-agent-modeling.md
+++ b/docs/superpowers/plans/2026-09-02-end-to-end-multi-agent-modeling.md
@@ -38,7 +38,7 @@ The decision analyst returns `decision_contract_candidate.v1`; the ontology mode
 - [x] **Step 2: Run the focused test and verify RED**
 
 ```bash
-PYTHONPATH=src /Users/eddie/.local/bin/python3.11 -m unittest tests.test_agent_modeling
+PYTHONPATH=src python3.11 -m unittest tests.test_agent_modeling
 ```
 
 Expected: failure because the existing function accepts only two gateways and emits v1.
@@ -122,7 +122,7 @@ self.assertEqual(json.loads(output.read_text())["modeling_status"], "ready_for_h
 - [x] **Step 2: Verify RED**
 
 ```bash
-PYTHONPATH=src /Users/eddie/.local/bin/python3.11 -m unittest tests.test_agent_modeling_cli
+PYTHONPATH=src python3.11 -m unittest tests.test_agent_modeling_cli
 ```
 
 Expected: failure because the CLI creates only two role gateways.
@@ -134,7 +134,7 @@ Instantiate three gateways with the existing configuration and keep `ontopoc-age
 - [x] **Step 4: Verify locally and against DeepSeek**
 
 ```bash
-PYTHONPATH=src /Users/eddie/.local/bin/python3.11 -m unittest \
+PYTHONPATH=src python3.11 -m unittest \
   tests.test_agent_modeling tests.test_agent_modeling_cli \
   tests.test_decision_pack tests.test_provided_compiler tests.test_spec_compiler
 git diff --check

--- a/docs/superpowers/plans/2026-09-02-minimal-multi-agent-modeling.md
+++ b/docs/superpowers/plans/2026-09-02-minimal-multi-agent-modeling.md
@@ -32,7 +32,7 @@ The fake modeler returns objects and relations whose `evidence_span` values occu
 Run:
 
 ```bash
-PYTHONPATH=src /Users/eddie/.local/bin/python3.11 -m unittest tests.test_agent_modeling
+PYTHONPATH=src python3.11 -m unittest tests.test_agent_modeling
 ```
 
 Expected: import failure because `agent_modeling` does not exist.
@@ -80,7 +80,7 @@ Patch the existing gateway with an offline fake. Assert the CLI reads credential
 Run:
 
 ```bash
-PYTHONPATH=src /Users/eddie/.local/bin/python3.11 -m unittest tests.test_agent_modeling_cli
+PYTHONPATH=src python3.11 -m unittest tests.test_agent_modeling_cli
 ```
 
 Expected: import failure because `agent_modeling_cli` does not exist.
@@ -100,7 +100,7 @@ Reuse the existing atomic writer and output-collision check. Register only `onto
 Run:
 
 ```bash
-PYTHONPATH=src /Users/eddie/.local/bin/python3.11 -m unittest tests.test_agent_modeling tests.test_agent_modeling_cli
+PYTHONPATH=src python3.11 -m unittest tests.test_agent_modeling tests.test_agent_modeling_cli
 git diff --check
 ```
 

--- a/landing-page/design-qa.md
+++ b/landing-page/design-qa.md
@@ -2,9 +2,9 @@
 
 ## Evidence
 
-- Source visual truth: `/Users/eddie/Desktop/Screenshot 2026-08-29 at 4.08.45 PM.png`
-- Implementation: `/tmp/ontopoc-demo-desktop-ontology-graph.png`
-- Side-by-side comparison: `/tmp/ontopoc-graph-design-comparison.png`
+- Source visual truth: local screenshot, 2026-08-29 (not committed)
+- Implementation: local temporary screenshot (not committed)
+- Side-by-side comparison: local temporary screenshot (not committed)
 - Source pixels: `2522 × 1114`
 - Implementation pixels and CSS viewport: `1440 × 900` at device scale factor `1`
 - Comparison normalization: both full views were scaled to a common comparison height without changing aspect ratio; browser chrome was excluded from the implementation capture.


### PR DESCRIPTION
Replaces machine-specific absolute paths (home directory, local screenshots, local Python binary) in five docs with repo-relative paths or placeholders. Docs only; no code or test changes.